### PR TITLE
feat(backend): estandarizar contrato API global y manejo de errores (HU-00)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Thumbs.db
 
 # Docker
 *.pid
+
+.yarn/install-state.gz

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -56,3 +56,6 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 /generated/prisma
+
+.yarn/install-state.gz
+

--- a/backend/api.http
+++ b/backend/api.http
@@ -1,0 +1,2 @@
+@baseUrl = http://localhost:3000
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,8 @@
     "@nestjs/websockets": "^11.1.12",
     "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "7",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.3",
     "pg": "^8.17.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/backend/src/common/filters/global-exception.filter.ts
+++ b/backend/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,57 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ApiResponse } from '../types/api-response.type';
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message = this.resolveMessage(exception);
+
+    const body: ApiResponse<null> = {
+      success: false,
+      message,
+      data: null,
+    };
+
+    response.status(status).json(body);
+  }
+
+  private resolveMessage(exception: unknown): string {
+    if (exception instanceof HttpException) {
+      const errorResponse = exception.getResponse();
+
+      if (
+        typeof errorResponse === 'object' &&
+        errorResponse !== null &&
+        'message' in errorResponse
+      ) {
+        const msg = (errorResponse as { message: string | string[] }).message;
+        return Array.isArray(msg) ? msg.join(', ') : msg;
+      }
+
+      if (typeof errorResponse === 'string') {
+        return errorResponse;
+      }
+    }
+
+    if (exception instanceof Error) {
+      return exception.message;
+    }
+
+    return 'Error interno del servidor';
+  }
+}

--- a/backend/src/common/interceptors/transform.interceptor.ts
+++ b/backend/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,48 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiResponse } from '../types/api-response.type';
+
+@Injectable()
+export class TransformInterceptor<T>
+  implements NestInterceptor<T, ApiResponse<unknown>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<ApiResponse<unknown>> {
+    return next.handle().pipe(
+      map((data: unknown) => {
+        let message = 'Operación realizada con éxito';
+        let responseData: unknown = data;
+
+        if (
+          data &&
+          typeof data === 'object' &&
+          !Array.isArray(data) &&
+          'message' in data &&
+          typeof (data as { message?: unknown }).message === 'string'
+        ) {
+          const { message: customMessage, ...rest } = data as {
+            message: string;
+            [key: string]: unknown;
+          };
+
+          message = customMessage;
+          responseData = Object.keys(rest).length > 0 ? rest : null;
+        }
+
+        return {
+          success: true,
+          message,
+          data: responseData,
+        };
+      }),
+    );
+  }
+}

--- a/backend/src/common/interceptors/transform.interceptor.ts
+++ b/backend/src/common/interceptors/transform.interceptor.ts
@@ -40,7 +40,7 @@ export class TransformInterceptor<T>
         return {
           success: true,
           message,
-          data: responseData,
+          data: responseData === undefined ? null : responseData,
         };
       }),
     );

--- a/backend/src/common/types/api-response.type.ts
+++ b/backend/src/common/types/api-response.type.ts
@@ -1,0 +1,5 @@
+export type ApiResponse<T> = {
+  success: boolean;
+  message: string;
+  data: T | null;
+};

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,20 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  app.useGlobalInterceptors(new TransformInterceptor());
+  app.useGlobalFilters(new GlobalExceptionFilter());
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2164,6 +2164,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/validator@npm:^13.15.3":
+  version: 13.15.10
+  resolution: "@types/validator@npm:13.15.10"
+  checksum: 10c0/3e2e65fcd37dd6961ca3fd0535293d0c42f5911dc3ca44b96f458835e6db2392b678ccbb0c9815d8c0a14e653439e6c62c7b8758a6cd1d6e390551c9e56618ac
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -3004,6 +3011,8 @@ __metadata:
     "@types/node": "npm:^22.10.7"
     "@types/pg": "npm:^8"
     "@types/supertest": "npm:^6.0.2"
+    class-transformer: "npm:^0.5.1"
+    class-validator: "npm:^0.14.3"
     eslint: "npm:^9.18.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-prettier: "npm:^5.2.2"
@@ -3358,6 +3367,24 @@ __metadata:
   version: 2.2.0
   resolution: "cjs-module-lexer@npm:2.2.0"
   checksum: 10c0/aec4ca58f87145fac221386790ecaae8b012f2e2359a45acb61d8c75ea4fa84f6ea869f17abc1a7e91a808eff0fed581209632f03540de16f72f0a28f5fd35ac
+  languageName: node
+  linkType: hard
+
+"class-transformer@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "class-transformer@npm:0.5.1"
+  checksum: 10c0/19809914e51c6db42c036166839906420bb60367df14e15f49c45c8c1231bf25ae661ebe94736ee29cc688b77101ef851a8acca299375cc52fc141b64acde18a
+  languageName: node
+  linkType: hard
+
+"class-validator@npm:^0.14.3":
+  version: 0.14.3
+  resolution: "class-validator@npm:0.14.3"
+  dependencies:
+    "@types/validator": "npm:^13.15.3"
+    libphonenumber-js: "npm:^1.11.1"
+    validator: "npm:^13.15.20"
+  checksum: 10c0/6d451c359aecb04479b95034b10cca02015d3b6f34480574c618c070e12f3676cb4cdfa76bfa61353356a483ff01326e9ce3f07ef584be6c31806190117f7fa4
   languageName: node
   linkType: hard
 
@@ -5695,6 +5722,13 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"libphonenumber-js@npm:^1.11.1":
+  version: 1.12.36
+  resolution: "libphonenumber-js@npm:1.12.36"
+  checksum: 10c0/1bf9e3f24aba0b4d9748642db52a698641c0746eb4e0706d13f9ae076ed18c0c9ff814323ebb130b1ad2b17d0894b7cd33463bea009fc5efac3feaeb1d17b865
   languageName: node
   linkType: hard
 
@@ -8070,6 +8104,13 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/e6897ed2008fc900380a6ce39b62bc5fca45fd5e070f70571c6380ede3ba026d0b7016230215d87f7f3d672a28dbde5a0522d39830b493fdc3dccd1a59ef4ee6
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.15.20":
+  version: 13.15.26
+  resolution: "validator@npm:13.15.26"
+  checksum: 10c0/d66041685c531423f6b514d0481228503b96682fe30ed7925ad77ff3cd08c3983dc94f45e18457e44f62f89027b94a3342009d65421800ce65f6e0d2c6eaf7fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Resumen
Implementa la HU-00 para unificar el contrato de respuesta de la API en NestJS.

## Cambios principales
- Se añade `ApiResponse<T>` en `src/common/types/api-response.type.ts`.
- Se añade `TransformInterceptor` global para respuestas exitosas.
- Se añade `GlobalExceptionFilter` global para errores.
- Se registra en `main.ts`:
  - `ValidationPipe` global (`whitelist`, `forbidNonWhitelisted`, `transform`)
  - `TransformInterceptor` global
  - `GlobalExceptionFilter` global
- Se añaden dependencias necesarias para validación:
  - `class-validator`
  - `class-transformer`
- Se actualiza `.gitignore` para ignorar `backend/.yarn/install-state.gz`.

## Verificación
- `yarn build` en `backend` OK.
- Contrato esperado:
  - Éxito: `{ success: true, message: string, data: T | null }`
  - Error: `{ success: false, message: string, data: null }`

## Notas
- No se incluye documentación en esta PR (se hará en rama de docs).
- No se incluye logging server-side en el filter por decisión de alcance actual.
