### PR TITLE
HU-15: Panel de administrador frontend mockeado con acceso visual por rol ADMIN

### DIFF
--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,9 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
+import {
+  getAuthSession,
+  subscribeToAuthSession,
+  userHasAdminRole,
+} from '../../../features/auth/utils/auth-session.storage';
 import './Header.css';
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [sessionUser, setSessionUser] = useState(() => getAuthSession().user);
+
+  useEffect(() => {
+    // aquí se escuchann cambios de sesión para actualizar el botón del header sin recargar la página
+    const unsubscribe = subscribeToAuthSession(() => {
+      setSessionUser(getAuthSession().user);
+    });
+
+    return unsubscribe;
+  }, []);
 
   const navItems = [
     { label: 'Inicio', to: '/', end: true },
@@ -15,6 +30,9 @@ export const Header = () => {
     { label: 'Colabora', to: '/colabora' },
     { label: 'Contacto', to: '/contacto' },
   ];
+
+  
+  const isAdmin = userHasAdminRole(sessionUser);
 
   const toggleMenu = () => {
     setIsMenuOpen((prevState) => !prevState);
@@ -69,10 +87,17 @@ export const Header = () => {
               ))}
             </ul>
 
-            <Link to="/auth/login" className="btn btn-brand ms-lg-3" onClick={closeMenu}>
-              <i className="bi bi-person-circle me-2" />
-              Acceso
-            </Link>
+            {isAdmin ? (
+              <Link to="/admin" className="btn btn-brand ms-lg-3" onClick={closeMenu}>
+                <i className="bi bi-speedometer2 me-2" />
+                Panel Admin
+              </Link>
+            ) : (
+              <Link to="/auth/login" className="btn btn-brand ms-lg-3" onClick={closeMenu}>
+                <i className="bi bi-person-circle me-2" />
+                Acceso
+              </Link>
+            )}
           </div>
         </div>
       </nav>

--- a/frontend/src/features/admin/components/dashboard/AdminListCard/AdminListCard.css
+++ b/frontend/src/features/admin/components/dashboard/AdminListCard/AdminListCard.css
@@ -1,0 +1,33 @@
+.admin-list-card {
+  background: var(--brand-white);
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 1rem;
+}
+
+.admin-list-card__header {
+  padding: 0.25rem 0.25rem 0.75rem;
+}
+
+.admin-list-card__title {
+  margin: 0;
+  color: var(--brand-dark);
+  font-size: 1.35rem;
+  font-weight: 800;
+}
+
+.admin-list-card__items {
+  display: grid;
+  gap: 0.85rem;
+}
+
+@media (max-width: 575.98px) {
+  .admin-list-card {
+    padding: 0.85rem;
+  }
+
+  .admin-list-card__title {
+    font-size: 1.15rem;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminListCard/AdminListCard.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminListCard/AdminListCard.tsx
@@ -1,0 +1,25 @@
+import type { AdminListBlock } from '../../../types/admin-panel.types';
+import { AdminListItem } from '../AdminListItem/AdminListItem';
+import './AdminListCard.css';
+
+type AdminListCardProps = {
+  block: AdminListBlock;
+};
+
+export const AdminListCard = ({ block }: AdminListCardProps) => {
+  return (
+    <section className="admin-list-card" aria-labelledby={`admin-list-card-${block.key}`}>
+      <div className="admin-list-card__header">
+        <h2 id={`admin-list-card-${block.key}`} className="admin-list-card__title">
+          {block.title}
+        </h2>
+      </div>
+
+      <div className="admin-list-card__items">
+        {block.items.map((item) => (
+          <AdminListItem key={item.id} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/features/admin/components/dashboard/AdminListItem/AdminListItem.css
+++ b/frontend/src/features/admin/components/dashboard/AdminListItem/AdminListItem.css
@@ -1,0 +1,77 @@
+.admin-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background-color: var(--brand-white);
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius-md);
+  padding: 0.95rem 1rem;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.04);
+}
+
+.admin-list-item__content {
+  min-width: 0;
+}
+
+.admin-list-item__title {
+  margin: 0;
+  color: var(--brand-dark);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.admin-list-item__meta {
+  margin: 0.2rem 0 0;
+  color: var(--brand-muted);
+  font-size: 0.92rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.admin-list-item__badge {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+
+.admin-list-item__badge--pendiente {
+  background: rgba(245, 158, 11, 0.14);
+  color: #b45309;
+  border-color: rgba(245, 158, 11, 0.24);
+}
+
+.admin-list-item__badge--aprobado {
+  background: rgba(22, 163, 74, 0.12);
+  color: #166534;
+  border-color: rgba(22, 163, 74, 0.22);
+}
+
+.admin-list-item__badge--rechazado {
+  background: rgba(220, 38, 38, 0.1);
+  color: #b91c1c;
+  border-color: rgba(220, 38, 38, 0.2);
+}
+
+.admin-list-item__badge--publicado {
+  background: rgba(0, 92, 159, 0.12);
+  color: var(--brand-primary);
+  border-color: rgba(0, 92, 159, 0.2);
+}
+
+@media (max-width: 767.98px) {
+  .admin-list-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .admin-list-item__badge {
+    align-self: flex-start;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminListItem/AdminListItem.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminListItem/AdminListItem.tsx
@@ -1,0 +1,37 @@
+import type {
+  AdminDashboardListItem,
+  AdminListItemStatus,
+} from '../../../types/admin-panel.types';
+import './AdminListItem.css';
+
+type AdminListItemProps = {
+  item: AdminDashboardListItem;
+};
+
+const statusLabelMap: Record<AdminListItemStatus, string> = {
+  PENDIENTE: 'Pendiente',
+  APROBADO: 'Aprobado',
+  RECHAZADO: 'Rechazado',
+  PUBLICADO: 'Publicado',
+};
+
+export const AdminListItem = ({ item }: AdminListItemProps) => {
+  return (
+    <article className="admin-list-item" aria-label={`${item.title} - ${item.status}`}>
+      <div className="admin-list-item__content">
+        <p className="admin-list-item__title">{item.title}</p>
+        <p className="admin-list-item__meta">
+          <span>{item.subtitle}</span>
+          <span aria-hidden="true">·</span>
+          <time dateTime={item.date}>{item.date}</time>
+        </p>
+      </div>
+
+      <span
+        className={`admin-list-item__badge admin-list-item__badge--${item.status.toLowerCase()}`}
+      >
+        {statusLabelMap[item.status]}
+      </span>
+    </article>
+  );
+};

--- a/frontend/src/features/admin/components/dashboard/AdminQuickActionButton/AdminQuickActionButton.css
+++ b/frontend/src/features/admin/components/dashboard/AdminQuickActionButton/AdminQuickActionButton.css
@@ -1,0 +1,54 @@
+.admin-quick-action-button {
+  border-radius: var(--radius-md);
+  padding: 0.8rem 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.admin-quick-action-button__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.admin-quick-action-button--solid {
+  background: linear-gradient(135deg, var(--brand-primary) 0%, #0a78c2 100%);
+  color: var(--brand-white);
+  border-color: transparent;
+  box-shadow: 0 8px 20px rgba(0, 92, 159, 0.2);
+}
+
+.admin-quick-action-button--solid:hover,
+.admin-quick-action-button--solid:focus-visible {
+  background: linear-gradient(135deg, #004d85 0%, var(--brand-primary) 100%);
+  color: var(--brand-white);
+  outline: none;
+}
+
+.admin-quick-action-button--outline {
+  background: var(--brand-white);
+  color: var(--brand-dark);
+  border-color: #d1d5db;
+}
+
+.admin-quick-action-button--outline:hover,
+.admin-quick-action-button--outline:focus-visible {
+  background: #f8fafc;
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+  outline: none;
+}
+
+@media (max-width: 575.98px) {
+  .admin-quick-action-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminQuickActionButton/AdminQuickActionButton.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminQuickActionButton/AdminQuickActionButton.tsx
@@ -1,0 +1,21 @@
+import type { AdminQuickAction } from '../../../types/admin-panel.types';
+import './AdminQuickActionButton.css';
+
+type AdminQuickActionButtonProps = {
+  action: AdminQuickAction;
+};
+
+export const AdminQuickActionButton = ({
+  action,
+}: AdminQuickActionButtonProps) => {
+  return (
+    <button
+      type="button"
+      className={`admin-quick-action-button admin-quick-action-button--${action.variant}`}
+      aria-label={`Acción rápida: ${action.label}`}
+    >
+      <i className={`${action.icon} admin-quick-action-button__icon`} aria-hidden="true" />
+      <span>{action.label}</span>
+    </button>
+  );
+};

--- a/frontend/src/features/admin/components/dashboard/AdminQuickActions/AdminQuickActions.css
+++ b/frontend/src/features/admin/components/dashboard/AdminQuickActions/AdminQuickActions.css
@@ -1,0 +1,13 @@
+.admin-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+@media (max-width: 575.98px) {
+  .admin-quick-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminQuickActions/AdminQuickActions.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminQuickActions/AdminQuickActions.tsx
@@ -1,0 +1,17 @@
+import type { AdminQuickAction } from '../../../types/admin-panel.types';
+import { AdminQuickActionButton } from '../AdminQuickActionButton/AdminQuickActionButton';
+import './AdminQuickActions.css';
+
+type AdminQuickActionsProps = {
+  actions: AdminQuickAction[];
+};
+
+export const AdminQuickActions = ({ actions }: AdminQuickActionsProps) => {
+  return (
+    <section className="admin-quick-actions" aria-label="Acciones rápidas del panel">
+      {actions.map((action) => (
+        <AdminQuickActionButton key={action.id} action={action} />
+      ))}
+    </section>
+  );
+};

--- a/frontend/src/features/admin/components/dashboard/AdminStatCard/AdminStatCard.css
+++ b/frontend/src/features/admin/components/dashboard/AdminStatCard/AdminStatCard.css
@@ -1,0 +1,65 @@
+.admin-stat-card {
+  background-color: var(--brand-white);
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 1.25rem 1.35rem;
+  min-height: 110px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.admin-stat-card::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  background-color: var(--admin-stat-accent, var(--brand-primary));
+}
+
+.admin-stat-card__label {
+  margin: 0;
+  color: var(--brand-muted);
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+.admin-stat-card__value {
+  margin: 0;
+  color: var(--admin-stat-accent, var(--brand-primary));
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.admin-stat-card--primary {
+  --admin-stat-accent: var(--brand-primary);
+}
+
+.admin-stat-card--warning {
+  --admin-stat-accent: #d97706;
+}
+
+.admin-stat-card--info {
+  --admin-stat-accent: #2563eb;
+}
+
+.admin-stat-card--success {
+  --admin-stat-accent: #15803d;
+}
+
+@media (max-width: 575.98px) {
+  .admin-stat-card {
+    min-height: 96px;
+    padding: 1rem 1.1rem;
+  }
+
+  .admin-stat-card__label {
+    font-size: 0.92rem;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminStatCard/AdminStatCard.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminStatCard/AdminStatCard.tsx
@@ -1,0 +1,20 @@
+import type { AdminMetric } from '../../../types/admin-panel.types';
+import './AdminStatCard.css';
+
+type AdminStatCardProps = {
+  metric: AdminMetric;
+};
+
+export const AdminStatCard = ({ metric }: AdminStatCardProps) => {
+  return (
+    <article
+      className={`admin-stat-card admin-stat-card--${metric.accent}`}
+      aria-label={`Métrica: ${metric.label}`}
+    >
+      <p className="admin-stat-card__label">{metric.label}</p>
+      <p className="admin-stat-card__value" aria-live="polite">
+        {metric.value}
+      </p>
+    </article>
+  );
+};

--- a/frontend/src/features/admin/components/dashboard/AdminStatsGrid/AdminStatsGrid.css
+++ b/frontend/src/features/admin/components/dashboard/AdminStatsGrid/AdminStatsGrid.css
@@ -1,0 +1,17 @@
+.admin-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 1199.98px) {
+  .admin-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 575.98px) {
+  .admin-stats-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/features/admin/components/dashboard/AdminStatsGrid/AdminStatsGrid.tsx
+++ b/frontend/src/features/admin/components/dashboard/AdminStatsGrid/AdminStatsGrid.tsx
@@ -1,0 +1,17 @@
+import type { AdminMetric } from '../../../types/admin-panel.types';
+import { AdminStatCard } from '../AdminStatCard/AdminStatCard';
+import './AdminStatsGrid.css';
+
+type AdminStatsGridProps = {
+  metrics: AdminMetric[];
+};
+
+export const AdminStatsGrid = ({ metrics }: AdminStatsGridProps) => {
+  return (
+    <section className="admin-stats-grid" aria-label="Resumen de métricas del panel">
+      {metrics.map((metric) => (
+        <AdminStatCard key={metric.key} metric={metric} />
+      ))}
+    </section>
+  );
+};

--- a/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.css
+++ b/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.css
@@ -1,0 +1,152 @@
+.admin-layout {
+  min-height: 100vh;
+  display: flex;
+  background: var(--brand-bg);
+}
+
+.admin-layout__sidebar {
+  width: 260px;
+  background: linear-gradient(
+    180deg,
+    var(--brand-primary) 0%,
+    #0a78c2 55%,
+    var(--brand-secondary) 100%
+  );
+  color: var(--brand-white);
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.admin-layout__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.25rem 1rem;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.admin-layout__brand-icon {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.admin-layout__nav {
+  flex: 1;
+  margin-top: 0.5rem;
+}
+
+.admin-layout__nav-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.admin-layout__nav-item {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  transition: background-color 0.2s ease;
+}
+
+.admin-layout__nav-item:hover,
+.admin-layout__nav-item:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+
+.admin-layout__nav-item--active {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--brand-white);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: inset 3px 0 0 rgba(255, 255, 255, 0.55);
+}
+
+.admin-layout__logout {
+  margin-top: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: inherit;
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+}
+
+.admin-layout__logout:hover,
+.admin-layout__logout:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.admin-layout__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-layout__topbar {
+  min-height: 72px;
+  background: var(--brand-white);
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+}
+
+.admin-layout__title {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--brand-dark);
+}
+
+.admin-layout__context {
+  color: var(--brand-muted);
+  font-size: 0.95rem;
+}
+
+.admin-layout__content {
+  padding: 1.5rem;
+}
+
+@media (max-width: 991.98px) {
+  .admin-layout {
+    flex-direction: column;
+  }
+
+  .admin-layout__sidebar {
+    width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .admin-layout__nav-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .admin-layout__topbar {
+    padding: 1rem;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .admin-layout__nav-list {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-layout__title {
+    font-size: 1.4rem;
+  }
+}

--- a/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import { Outlet } from 'react-router-dom';
+import {
+  getAuthSession,
+  subscribeToAuthSession,
+  userHasAdminRole,
+} from '../../../../auth/utils/auth-session.storage';
+import './AdminLayout.css';
+
+const sidebarItems = [
+  'Panel',
+  'Campanas',
+  'Noticias',
+  'Retos',
+  'Solicitudes',
+  'Propuestas',
+  'Chat',
+];
+
+export const AdminLayout = () => {
+  const [sessionUser, setSessionUser] = useState(() => getAuthSession().user);
+
+  useEffect(() => {
+    // Sincroniza la UI del panel si cambia la sesión (login/logout) sin recargar.
+    const unsubscribe = subscribeToAuthSession(() => {
+      setSessionUser(getAuthSession().user);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const isAdmin = userHasAdminRole(sessionUser);
+  const topbarEmail = sessionUser?.email ?? '';
+  const topbarRole = sessionUser?.roles?.[0]
+    ? sessionUser.roles[0].charAt(0).toUpperCase() +
+      sessionUser.roles[0].slice(1).toLowerCase()
+    : '';
+
+  return (
+    <div className="admin-layout">
+      <aside className="admin-layout__sidebar" aria-label="Navegacion del panel">
+        <div className="admin-layout__brand">
+          <span className="admin-layout__brand-icon" aria-hidden="true">
+            <i className="bi bi-shield-lock" />
+          </span>
+          <span className="admin-layout__brand-text">Administración</span>
+        </div>
+
+        <nav className="admin-layout__nav">
+          <ul className="admin-layout__nav-list">
+            {sidebarItems.map((item) => (
+              <li key={item}>
+                <button
+                  type="button"
+                  className={`admin-layout__nav-item ${
+                    item === 'Panel' ? 'admin-layout__nav-item--active' : ''
+                  }`}
+                >
+                  {item}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <button type="button" className="admin-layout__logout">
+          <i className="bi bi-box-arrow-left me-2" aria-hidden="true" />
+          Salir
+        </button>
+      </aside>
+
+      <div className="admin-layout__main">
+        <header className="admin-layout__topbar">
+          <h1 className="admin-layout__title">Panel</h1>
+          <p className="admin-layout__context mb-0">
+            {isAdmin ? `${topbarRole} · ${topbarEmail}` : 'Acceso restringido'}
+          </p>
+        </header>
+
+        <main className="admin-layout__content">
+          {isAdmin ? (
+            <Outlet />
+          ) : (
+            <section className="container-fluid px-0">
+              <div className="card border-0 shadow-sm">
+                <div className="card-body p-4">
+                  <h2 className="h4 mb-3">Acceso no autorizado al panel</h2>
+                  <p className="mb-2">
+                    Esta vista está disponible solo para usuarios con rol <code>ADMIN</code>.
+                  </p>
+                  <p className="mb-0 text-muted">
+                    Inicia sesión con una cuenta administradora para acceder al panel.
+                  </p>
+                </div>
+              </div>
+            </section>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Link, Outlet } from 'react-router-dom';
 import {
   getAuthSession,
   subscribeToAuthSession,
@@ -63,10 +63,14 @@ export const AdminLayout = () => {
           </ul>
         </nav>
 
-        <button type="button" className="admin-layout__logout">
+        <Link
+          to="/"
+          className="admin-layout__logout"
+          aria-label="Volver a la página principal"
+        >
           <i className="bi bi-box-arrow-left me-2" aria-hidden="true" />
           Salir
-        </button>
+        </Link>
       </aside>
 
       <div className="admin-layout__main">

--- a/frontend/src/features/admin/mocks/admin-panel.mocks.ts
+++ b/frontend/src/features/admin/mocks/admin-panel.mocks.ts
@@ -1,0 +1,127 @@
+import type {
+  AdminListBlock,
+  AdminMetric,
+  AdminQuickAction,
+} from '../types/admin-panel.types';
+
+export const adminMetricsMock: AdminMetric[] = [
+  {
+    key: 'activeCampaigns',
+    label: 'Campañas Activas',
+    value: 3,
+    accent: 'primary',
+  },
+  {
+    key: 'pendingRequests',
+    label: 'Solicitudes Pendientes',
+    value: 2,
+    accent: 'warning',
+  },
+  {
+    key: 'pendingProposals',
+    label: 'Propuestas Pendientes',
+    value: 1,
+    accent: 'info',
+  },
+  {
+    key: 'unreadMessages',
+    label: 'Mensajes sin leer',
+    value: 1,
+    accent: 'success',
+  },
+];
+
+export const adminListBlocksMock: AdminListBlock[] = [
+  {
+    key: 'latestRequests',
+    title: 'Últimas Solicitudes',
+    items: [
+      {
+        id: 'request-1',
+        title: 'Laura Fernández',
+        subtitle: 'Voluntariado',
+        date: '2025-12-10',
+        status: 'PENDIENTE',
+      },
+      {
+        id: 'request-2',
+        title: 'Miguel Torres',
+        subtitle: 'Socio',
+        date: '2025-12-08',
+        status: 'APROBADO',
+      },
+      {
+        id: 'request-3',
+        title: 'Elena Ruiz',
+        subtitle: 'Contacto',
+        date: '2025-12-05',
+        status: 'PENDIENTE',
+      },
+      {
+        id: 'request-4',
+        title: 'Javier Moreno',
+        subtitle: 'Donación',
+        date: '2025-12-01',
+        status: 'RECHAZADO',
+      },
+    ],
+  },
+  {
+    key: 'productProposals',
+    title: 'Propuestas de Productos',
+    items: [
+      {
+        id: 'proposal-1',
+        title: 'Quinoa orgánica',
+        subtitle: 'BioAndes',
+        date: '2025-12-12',
+        status: 'PENDIENTE',
+      },
+      {
+        id: 'proposal-2',
+        title: 'Cestería artesanal',
+        subtitle: 'ArteManos',
+        date: '2025-12-08',
+        status: 'APROBADO',
+      },
+      {
+        id: 'proposal-3',
+        title: 'Aceite de argán',
+        subtitle: 'CoopArgán',
+        date: '2025-11-25',
+        status: 'PUBLICADO',
+      },
+      {
+        id: 'proposal-4',
+        title: 'Especias de Tanzania',
+        subtitle: 'SpiceFair',
+        date: '2025-11-20',
+        status: 'RECHAZADO',
+      },
+    ],
+  },
+];
+
+export const adminQuickActionsMock: AdminQuickAction[] = [
+  {
+    id: 'new-campaign',
+    label: 'Nueva Campaña',
+    icon: 'bi bi-plus-lg',
+    variant: 'solid',
+    target: '/admin/campanas/nueva',
+  },
+  {
+    id: 'new-news',
+    label: 'Nueva Noticia',
+    icon: 'bi bi-plus-lg',
+    variant: 'outline',
+    target: '/admin/noticias/nueva',
+  },
+  {
+    id: 'view-requests',
+    label: 'Ver Solicitudes',
+    icon: 'bi bi-inbox',
+    variant: 'outline',
+    target: '/admin/solicitudes',
+  },
+];

--- a/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.css
+++ b/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.css
@@ -1,0 +1,16 @@
+.admin-panel-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-panel-page__lists {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+@media (max-width: 991.98px) {
+  .admin-panel-page__lists {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
+++ b/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
@@ -1,22 +1,10 @@
+import { adminMetricsMock } from '../../mocks/admin-panel.mocks';
+import { AdminStatsGrid } from '../../components/dashboard/AdminStatsGrid/AdminStatsGrid';
+
 export const AdminPanelPage = () => {
   return (
-    <section className="container py-5">
-      <div className="row justify-content-center">
-        <div className="col-12 col-lg-10">
-          <div className="card shadow-sm border-0">
-            <div className="card-body p-4">
-              <h1 className="h3 mb-3">Panel de administración</h1>
-              <p className="mb-2">
-                Ruta <code>/admin</code> operativa.
-              </p>
-              <p className="mb-0 text-muted">
-                En el siguiente bloque montaremos el layout del panel (sidebar + topbar +
-                contenido) y después los componentes del dashboard mockeado.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+    <section aria-label="Dashboard del panel de administración">
+      <AdminStatsGrid metrics={adminMetricsMock} />
     </section>
   );
 };

--- a/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
+++ b/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
@@ -1,0 +1,22 @@
+export const AdminPanelPage = () => {
+  return (
+    <section className="container py-5">
+      <div className="row justify-content-center">
+        <div className="col-12 col-lg-10">
+          <div className="card shadow-sm border-0">
+            <div className="card-body p-4">
+              <h1 className="h3 mb-3">Panel de administración</h1>
+              <p className="mb-2">
+                Ruta <code>/admin</code> operativa.
+              </p>
+              <p className="mb-0 text-muted">
+                En el siguiente bloque montaremos el layout del panel (sidebar + topbar +
+                contenido) y después los componentes del dashboard mockeado.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
+++ b/frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx
@@ -1,10 +1,25 @@
-import { adminMetricsMock } from '../../mocks/admin-panel.mocks';
+import {
+  adminListBlocksMock,
+  adminMetricsMock,
+  adminQuickActionsMock,
+} from '../../mocks/admin-panel.mocks';
+import { AdminListCard } from '../../components/dashboard/AdminListCard/AdminListCard';
+import { AdminQuickActions } from '../../components/dashboard/AdminQuickActions/AdminQuickActions';
 import { AdminStatsGrid } from '../../components/dashboard/AdminStatsGrid/AdminStatsGrid';
+import './AdminPanelPage.css';
 
 export const AdminPanelPage = () => {
   return (
-    <section aria-label="Dashboard del panel de administración">
+    <section className="admin-panel-page" aria-label="Dashboard del panel de administración">
       <AdminStatsGrid metrics={adminMetricsMock} />
+
+      <section className="admin-panel-page__lists" aria-label="Listas de gestión del panel">
+        {adminListBlocksMock.map((block) => (
+          <AdminListCard key={block.key} block={block} />
+        ))}
+      </section>
+
+      <AdminQuickActions actions={adminQuickActionsMock} />
     </section>
   );
 };

--- a/frontend/src/features/admin/types/admin-panel.types.ts
+++ b/frontend/src/features/admin/types/admin-panel.types.ts
@@ -1,0 +1,46 @@
+export type AdminMetricKey =
+  | 'activeCampaigns'
+  | 'pendingRequests'
+  | 'pendingProposals'
+  | 'unreadMessages';
+
+export type AdminMetricAccent = 'primary' | 'warning' | 'info' | 'success';
+
+export type AdminMetric = {
+  key: AdminMetricKey;
+  label: string;
+  value: number;
+  accent: AdminMetricAccent;
+};
+
+export type AdminListItemStatus =
+  | 'PENDIENTE'
+  | 'APROBADO'
+  | 'RECHAZADO'
+  | 'PUBLICADO';
+
+export type AdminDashboardListItem = {
+  id: string;
+  title: string;
+  subtitle: string;
+  date: string;
+  status: AdminListItemStatus;
+};
+
+export type AdminListBlockKey = 'latestRequests' | 'productProposals';
+
+export type AdminListBlock = {
+  key: AdminListBlockKey;
+  title: string;
+  items: AdminDashboardListItem[];
+};
+
+export type AdminQuickActionVariant = 'solid' | 'outline';
+
+export type AdminQuickAction = {
+  id: string;
+  label: string;
+  icon: string;
+  variant: AdminQuickActionVariant;
+  target?: string;
+};

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, FormEvent } from 'react';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { googleSignIn, login } from '../../api/auth.api';
+import { saveAuthSession } from '../../utils/auth-session.storage';
 import type { ApiResponse } from '../../../../types/api';
 import type { AuthResponseData } from '../../types/auth.api.types';
 import type { LoginFormState } from '../../types/auth.types';
@@ -111,7 +112,7 @@ export const LoginForm = () => {
           return;
         }
 
-        localStorage.setItem('accessToken', apiResponse.data.accessToken);
+        saveAuthSession(apiResponse.data);
         setFormState((prev) => ({
           ...prev,
           successMessage: apiResponse.message,
@@ -194,7 +195,7 @@ export const LoginForm = () => {
         return;
       }
 
-      localStorage.setItem('accessToken', response.data.accessToken);
+      saveAuthSession(response.data);
       setFormState((prev) => ({
         ...prev,
         successMessage: response.message,

--- a/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
@@ -4,6 +4,7 @@ import './RegisterForm.css';
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { register } from '../../api/auth.api';
+import { saveAuthSession } from '../../utils/auth-session.storage';
 import type { ApiResponse } from '../../../../types/api';
 import type { AuthResponseData } from '../../types/auth.api.types';
 
@@ -76,7 +77,7 @@ export const RegisterForm = () => {
         return;
       }
 
-      localStorage.setItem('accessToken', response.data.accessToken);
+      saveAuthSession(response.data);
       setFormState((prev) => ({
         ...prev,
         successMessage: response.message,

--- a/frontend/src/features/auth/utils/auth-session.storage.ts
+++ b/frontend/src/features/auth/utils/auth-session.storage.ts
@@ -1,0 +1,170 @@
+import type { AuthResponseData, AuthUser } from '../types/auth.api.types';
+
+/*
+  Comentarios dejados a consciencia para ayuda propia y del equipo cuando volvamos a revisar este archivo
+  He querido dejar todo este comentario ya que este helper es muy lioso pero la verdad que cuando he buscado como hacerlo
+  junto a la ia, me ha gustado mucho y creo puede ser una buena práctica hacerlo de esta manera,
+  y como siempre estoy pregúntandome como pueden mejorarse las cosas arquitéctonicamente pues he 
+  querido dejarlo, aunque lo más facil para mi hubiese sido guardar el user.role en el localstorage
+  y me iba a funcionar igual pero me chirriaba verlo así por lo tanto he decidido hacer esto.
+  
+  Este archivo centraliza la gestión de la sesión en frontend (token + usuario).
+
+  - La HU15 necesita saber si el usuario autenticado tiene rol ADMIN para mostrar
+    el botón "Panel Admin" en el Header.
+  - El backend ya devuelve ese dato en login/register/google (`user.roles`), pero
+    si cada componente accede directamente a localStorage por su cuenta:
+      1) duplicamos lógica,
+      2) es más fácil cometer errores,
+      3) es más difícil mantener y explicar el código.
+
+  ¿Qué hace este helper?
+  - Guarda la sesión (`saveAuthSession`)
+  - Lee la sesión (`getAuthSession`)
+  - Limpia la sesión (`clearAuthSession`)
+  - Comprueba si un usuario es admin (`userHasAdminRole`)
+  - Permite que componentes (por ejemplo Header) se actualicen cuando cambia la sesión
+    (`subscribeToAuthSession`)
+
+  ¿Por qué está bien a nivel arquitectura?
+  - Separamos responsabilidades:
+    - formularios de login/register: autentican
+    - helper de sesión: persiste/lee sesión
+    - componentes UI (Header, panel): solo consumen datos
+  - Facilita futuras mejoras (Context, logout, refresh token) sin reescribir todo.
+*/
+
+const ACCESS_TOKEN_STORAGE_KEY = 'accessToken';
+const AUTH_USER_STORAGE_KEY = 'authUser';
+
+// Evento propio para avisar a la misma pestaña de que la sesión ha cambiado.
+// El evento nativo `storage` no siempre se dispara en la misma pestaña que modifica localStorage.
+export const AUTH_SESSION_CHANGE_EVENT = 'auth-session-changed';
+
+type AuthSessionSnapshot = {
+  accessToken: string | null;
+  user: AuthUser | null;
+};
+
+// Protección por si en el futuro este código se ejecuta fuera del navegador
+// (tests, SSR, etc.). Así evitamos errores al acceder a `window` o `localStorage`.
+const isBrowser = typeof window !== 'undefined';
+
+const notifyAuthSessionChanged = (): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  window.dispatchEvent(new Event(AUTH_SESSION_CHANGE_EVENT));
+};
+
+const parseStoredUser = (rawUser: string | null): AuthUser | null => {
+  if (!rawUser) {
+    return null;
+  }
+
+  try {
+    
+    const parsed = JSON.parse(rawUser) as Partial<AuthUser>;
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof parsed.id !== 'number' ||
+      typeof parsed.email !== 'string' ||
+      typeof parsed.name !== 'string' ||
+      typeof parsed.surname !== 'string' ||
+      !Array.isArray(parsed.roles)
+    ) {
+      return null;
+    }
+
+    return {
+      id: parsed.id,
+      email: parsed.email,
+      name: parsed.name,
+      surname: parsed.surname,
+      roles: parsed.roles.filter((role): role is string => typeof role === 'string'),
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const getAuthSession = (): AuthSessionSnapshot => {
+  if (!isBrowser) {
+    return {
+      accessToken: null,
+      user: null,
+    };
+  }
+
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+  const user = parseStoredUser(localStorage.getItem(AUTH_USER_STORAGE_KEY));
+
+  return {
+    accessToken,
+    user,
+  };
+};
+
+export const saveAuthSession = (data: AuthResponseData): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  // Guardamos token y usuario juntos porque la HU15 necesita `user.roles`
+  // para decidir si se muestra "Panel Admin".
+  localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, data.accessToken);
+  localStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(data.user));
+  notifyAuthSessionChanged();
+};
+
+export const clearAuthSession = (): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(AUTH_USER_STORAGE_KEY);
+  notifyAuthSessionChanged();
+};
+
+export const userHasAdminRole = (user: AuthUser | null | undefined): boolean => {
+  if (!user) {
+    return false;
+  }
+
+  
+  return user.roles.some((role) => role.toUpperCase() === 'ADMIN');
+};
+
+export const subscribeToAuthSession = (onChange: () => void): (() => void) => {
+  if (!isBrowser) {
+    return () => undefined;
+  }
+
+  const handleCustomChange = () => {
+    onChange();
+  };
+
+  const handleStorageChange = (event: StorageEvent) => {
+    // `storage` se usa para sincronizar cambios entre pestañas/ventanas.
+    if (
+      event.key === null ||
+      event.key === ACCESS_TOKEN_STORAGE_KEY ||
+      event.key === AUTH_USER_STORAGE_KEY
+    ) {
+      onChange();
+    }
+  };
+
+  window.addEventListener(AUTH_SESSION_CHANGE_EVENT, handleCustomChange);
+  window.addEventListener('storage', handleStorageChange);
+
+  return () => {
+    // Limpieza de listeners para evitar fugas de memoria cuando el componente se desmonta.
+    window.removeEventListener(AUTH_SESSION_CHANGE_EVENT, handleCustomChange);
+    window.removeEventListener('storage', handleStorageChange);
+  };
+};

--- a/frontend/src/features/auth/utils/auth-session.storage.ts
+++ b/frontend/src/features/auth/utils/auth-session.storage.ts
@@ -2,11 +2,14 @@ import type { AuthResponseData, AuthUser } from '../types/auth.api.types';
 
 /*
   Comentarios dejados a consciencia para ayuda propia y del equipo cuando volvamos a revisar este archivo
-  He querido dejar todo este comentario ya que este helper es muy lioso pero la verdad que cuando he buscado como hacerlo
+  He querido dejar todo este comentario ya que este helper es un poco lioso pero la verdad
+   que cuando he buscado como hacerlo
   junto a la ia, me ha gustado mucho y creo puede ser una buena práctica hacerlo de esta manera,
   y como siempre estoy pregúntandome como pueden mejorarse las cosas arquitéctonicamente pues he 
   querido dejarlo, aunque lo más facil para mi hubiese sido guardar el user.role en el localstorage
-  y me iba a funcionar igual pero me chirriaba verlo así por lo tanto he decidido hacer esto.
+  desde loginform.tsx y fuera
+  y me iba a funcionar igual pero me chirriaba verlo así por lo tanto he decidido buscar como separar
+  responsabilidades y como se haría en entorno corporativo he visto esta opción y he decicido hacerlo así
   
   Este archivo centraliza la gestión de la sesión en frontend (token + usuario).
 

--- a/frontend/src/features/auth/utils/auth-session.storage.ts
+++ b/frontend/src/features/auth/utils/auth-session.storage.ts
@@ -138,10 +138,25 @@ export const userHasAdminRole = (user: AuthUser | null | undefined): boolean => 
     return false;
   }
 
-  
   return user.roles.some((role) => role.toUpperCase() === 'ADMIN');
 };
 
+/*
+  subscribeToAuthSession sirve para que un componente (por ejemplo Header)
+  escuche cuándo cambia la sesión en localStorage para poder hacer csoitas después
+
+  Flujo de ejemplo para mostrar el bo´ton de panel de admin:
+  - Login/Register guarda sesión con saveAuthSession(...)
+  - saveAuthSession(...) lanza un evento de cambio
+  - Header (suscrito) recibe ese aviso
+  - Header vuelve a leer la sesión con getAuthSession()
+  - Header actualiza el botón (Acceso / Panel Admin) sin recargar
+
+  Importante:
+  - No modifica datos de sesión
+  - Solo notifica/escucha cambios
+  - Devuelve una función para cancelar la suscripción al desmontar el componente
+*/
 export const subscribeToAuthSession = (onChange: () => void): (() => void) => {
   if (!isBrowser) {
     return () => undefined;

--- a/frontend/src/router/app.router.tsx
+++ b/frontend/src/router/app.router.tsx
@@ -1,6 +1,8 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { HomePage } from '../features/home/pages/HomePage/HomePage';
 import { AuthPage } from '../features/auth/pages/AuthPage/AuthPage';
+import { AdminLayout } from '../features/admin/components/layout/AdminLayout/AdminLayout';
+import { AdminPanelPage } from '../features/admin/pages/AdminPanelPage/AdminPanelPage';
 import { PublicLayout } from './layouts/PublicLayout';
 import { NotFoundPage } from './pages/NotFoundPage';
 
@@ -24,6 +26,16 @@ export const appRouter = createBrowserRouter([
       {
         path: '*',
         element: <NotFoundPage />,
+      },
+    ],
+  },
+  {
+    path: '/admin',
+    element: <AdminLayout />,
+    children: [
+      {
+        index: true,
+        element: <AdminPanelPage />,
       },
     ],
   },


### PR DESCRIPTION
## 📌 HU relacionada
HU-15 — Panel de administrador (Componentes Frontend)

## ✅ Objetivo
Implementar una versión **mockeada** del panel de administración en frontend, con enfoque en **componentización React**, **tipado estricto**, **estructura por feature** y **acceso visual según rol ADMIN** usando `user.roles` real del backend.

## 🚀 Qué incluye esta PR

### 1) Integración de sesión frontend para rol ADMIN (sin mock)
- Persistencia de `user` + `accessToken` en frontend (no solo token)
- Helper de sesión reutilizable para:
  - leer sesión
  - guardar sesión
  - limpiar sesión (preparado para futuro)
  - comprobar si el usuario tiene rol `ADMIN`
  - suscribirse a cambios de sesión (sin recargar)

Archivos clave:
- `frontend/src/features/auth/utils/auth-session.storage.ts`
- `frontend/src/features/auth/components/LoginForm/LoginForm.tsx`
- `frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx`
- `frontend/src/components/layout/Header/Header.tsx`

### 2) Header público con botón `Panel Admin` por rol
- Si el usuario autenticado tiene `ADMIN` en `user.roles`:
  - se muestra `Panel Admin` en lugar de `Acceso`
- Si no:
  - se mantiene `Acceso`

### 3) Ruta `/admin` + layout propio de panel
- Nueva ruta `/admin`
- Layout admin separado del layout público
- Estructura base del panel:
  - sidebar (mock visual)
  - topbar
  - contenido principal

Archivos clave:
- `frontend/src/router/app.router.tsx`
- `frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.tsx`
- `frontend/src/features/admin/components/layout/AdminLayout/AdminLayout.css`

### 4) Topbar con datos reales de sesión + control visual de acceso
- Topbar muestra datos reales del usuario autenticado (rol/email) cuando es admin
- Si no es admin:
  - fallback visual de “Acceso restringido” en el panel (sin redirección)

### 5) Dashboard mockeado y modular (HU15 frontend-first)
Implementación de componentes reutilizables y datos mock tipados:

#### Tipos y mocks
- Tipos del dashboard admin
- Mocks tipados para:
  - métricas
  - listas (solicitudes/propuestas)
  - acciones rápidas

Archivos:
- `frontend/src/features/admin/types/admin-panel.types.ts`
- `frontend/src/features/admin/mocks/admin-panel.mocks.ts`

#### Componentes dashboard
- `AdminStatCard` (tarjeta de métrica reutilizable)
- `AdminStatsGrid` (contenedor de 4 métricas)
- `AdminListItem` (fila de lista con badge de estado)
- `AdminListCard` (bloque reutilizable de lista)
- `AdminQuickActionButton` (botón reutilizable)
- `AdminQuickActions` (contenedor de acciones rápidas)

Archivos:
- `frontend/src/features/admin/components/dashboard/AdminStatCard/AdminStatCard.tsx`
- `frontend/src/features/admin/components/dashboard/AdminStatsGrid/AdminStatsGrid.tsx`
- `frontend/src/features/admin/components/dashboard/AdminListItem/AdminListItem.tsx`
- `frontend/src/features/admin/components/dashboard/AdminListCard/AdminListCard.tsx`
- `frontend/src/features/admin/components/dashboard/AdminQuickActionButton/AdminQuickActionButton.tsx`
- `frontend/src/features/admin/components/dashboard/AdminQuickActions/AdminQuickActions.tsx`

#### Página del panel
- Ensamblado de métricas + listas + acciones mock
- Responsive básico (desktop/tablet/móvil funcional)

Archivo:
- `frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.tsx`
- `frontend/src/features/admin/pages/AdminPanelPage/AdminPanelPage.css`

### 6) Acción `Salir` del panel (sin logout)
- El botón `Salir` vuelve a la página principal (`/`)
- **No cierra sesión** (requisito funcional acordado para poder comprobar contenido público tras acciones admin)

---

## 🧱 Decisiones de arquitectura (importantes)
- Se mantiene estructura por `feature/admin` con separación de:
  - `components`
  - `pages`
  - `mocks`
  - `types`
- Se usa `user.roles` real del backend (no mock) para el acceso visual al panel
- Separamos componentes pequeños y contenedores (SRP):
  - `AdminStatCard` vs `AdminStatsGrid`
  - `AdminListItem` vs `AdminListCard`
  - `AdminQuickActionButton` vs `AdminQuickActions`

---

## 📝 No incluido en esta PR (intencionadamente)
- Colapsado real del sidebar (`collapsed`)
- Sidebar final/módulos visuales definitivos (queda para HU de compañero)
- Logout real (con `clearAuthSession`)
- Integración backend real de métricas/listas/acciones
- CRUD reales de módulos (`Campañas`, `Noticias`, etc.)

---


