### PR TITLE
style(auth): HU-19 Refactor UI Auth — Login, Registro, AuthPage y Header CTAs

### DIFF
--- a/frontend/src/components/layout/Header/Header.css
+++ b/frontend/src/components/layout/Header/Header.css
@@ -46,11 +46,17 @@
   align-items: center;
   justify-content: center;
   min-height: 38px;
-  border-radius: 0.7rem;
+  border-radius: var(--radius-md);
   font-size: 0.9rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-  padding: 0.45rem 0.95rem;
+  padding: 0.45rem 1rem;
+  transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.header-action-btn:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
 }
 
 .header-action-btn--main {
@@ -64,6 +70,7 @@
 .header-action-btn--main:focus {
   color: var(--brand-white);
   background: linear-gradient(135deg, #438a55, #286d5b);
+  box-shadow: 0 6px 12px rgba(39, 105, 70, 0.30);
 }
 
 .header-action-btn--donate {

--- a/frontend/src/features/auth/components/ForgotPasswordModal/ForgotPasswordModal.css
+++ b/frontend/src/features/auth/components/ForgotPasswordModal/ForgotPasswordModal.css
@@ -1,79 +1,97 @@
-.forgot-password-modal__backdrop {
+/* ── Forgot Password Modal ── */
+.forgot-modal__backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1050;
+  padding: 1rem;
 }
 
-.forgot-password-modal__content {
-  background: white;
-  border-radius: 0.5rem;
+.forgot-modal__content {
+  background: var(--auth-card-bg);
+  border-radius: var(--auth-card-radius);
+  box-shadow: var(--auth-card-shadow);
   padding: 2rem;
   max-width: 420px;
-  width: 90%;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  width: 100%;
   position: relative;
+  animation: puchRevealUp 380ms cubic-bezier(0.2, 0.75, 0.25, 1) forwards;
 }
 
-.forgot-password-modal__close {
+.forgot-modal__close {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   background: none;
   border: none;
-  font-size: 1.25rem;
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
   cursor: pointer;
-  color: var(--bs-secondary);
-  line-height: 1;
-  padding: 0.25rem;
+  color: var(--brand-muted);
+  transition: color 0.2s ease, background-color 0.2s ease;
 }
 
-.forgot-password-modal__close:hover {
-  color: var(--bs-dark);
+.forgot-modal__close:hover,
+.forgot-modal__close:focus {
+  color: var(--brand-dark);
+  background-color: rgba(13, 59, 115, 0.06);
 }
 
-.forgot-password-modal__title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+.forgot-modal__close:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
 }
 
-.forgot-password-modal__description {
-  color: var(--bs-secondary);
+.forgot-modal__title {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--brand-secondary);
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.015em;
+}
+
+.forgot-modal__description {
+  color: var(--brand-muted);
   font-size: 0.9rem;
   margin-bottom: 1.25rem;
+  line-height: 1.5;
 }
 
-.forgot-password-modal__input:focus {
-  border-color: var(--bs-primary);
-  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
-}
-
-.forgot-password-modal__btn {
+.forgot-modal__close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
-  padding: 0.75rem;
-  font-weight: 500;
+  min-height: 46px;
+  margin-top: 0.6rem;
+  border: 1.5px solid var(--auth-input-border);
+  border-radius: var(--radius-md);
+  padding: 0.65rem 1.2rem;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--brand-muted);
+  background: var(--brand-white);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
 }
 
-.forgot-password-modal__btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
+.forgot-modal__close-btn:hover,
+.forgot-modal__close-btn:focus {
+  border-color: var(--brand-secondary);
+  color: var(--brand-secondary);
 }
 
-.forgot-password-modal__error {
-  color: var(--bs-danger);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-}
-
-.forgot-password-modal__success {
-  color: var(--bs-success);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
+.forgot-modal__close-btn:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
 }

--- a/frontend/src/features/auth/components/ForgotPasswordModal/ForgotPasswordModal.tsx
+++ b/frontend/src/features/auth/components/ForgotPasswordModal/ForgotPasswordModal.tsx
@@ -58,38 +58,38 @@ export const ForgotPasswordModal = ({ onClose }: ForgotPasswordModalProps) => {
 
   return (
     <div
-      className="forgot-password-modal__backdrop"
+      className="forgot-modal__backdrop"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
       aria-labelledby="forgot-password-title"
     >
-      <div className="forgot-password-modal__content">
+      <div className="forgot-modal__content">
         <button
-          className="forgot-password-modal__close"
+          className="forgot-modal__close"
           onClick={onClose}
           aria-label="Cerrar"
           type="button"
         >
-          &times;
+          <i className="bi bi-x-lg" aria-hidden="true"></i>
         </button>
 
-        <h2 className="forgot-password-modal__title" id="forgot-password-title">
+        <h2 className="forgot-modal__title" id="forgot-password-title">
           ¿Olvidaste tu contraseña?
         </h2>
-        <p className="forgot-password-modal__description">
+        <p className="forgot-modal__description">
           Introduce tu correo electrónico y te enviaremos un enlace para
           restablecer tu contraseña.
         </p>
 
         <form onSubmit={handleSubmit} noValidate>
-          <div className="mb-3">
-            <label htmlFor="forgot-email" className="form-label">
+          <div className="auth-form__field">
+            <label htmlFor="forgot-email" className="auth-form__label">
               Correo electrónico
             </label>
             <input
               type="email"
-              className="form-control forgot-password-modal__input"
+              className="auth-form__input"
               id="forgot-email"
               value={email}
               onChange={handleChange}
@@ -102,13 +102,15 @@ export const ForgotPasswordModal = ({ onClose }: ForgotPasswordModalProps) => {
           </div>
 
           {successMessage && (
-            <div className="forgot-password-modal__success" role="status">
+            <div className="auth-form__feedback auth-form__feedback--success" role="status">
+              <i className="bi bi-check-circle-fill" aria-hidden="true"></i>
               {successMessage}
             </div>
           )}
 
           {error && (
-            <div className="forgot-password-modal__error" role="alert">
+            <div className="auth-form__feedback auth-form__feedback--error" role="alert">
+              <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
               {error}
             </div>
           )}
@@ -116,7 +118,7 @@ export const ForgotPasswordModal = ({ onClose }: ForgotPasswordModalProps) => {
           {!successMessage ? (
             <button
               type="submit"
-              className="btn btn-primary forgot-password-modal__btn mt-3"
+              className="btn-brand-auth auth-form__submit"
               disabled={loading || !email.trim()}
             >
               {loading ? (
@@ -126,7 +128,7 @@ export const ForgotPasswordModal = ({ onClose }: ForgotPasswordModalProps) => {
                     role="status"
                     aria-hidden="true"
                   ></span>
-                  Enviando...
+                  Enviando…
                 </>
               ) : (
                 'Enviar enlace de recuperación'
@@ -135,7 +137,7 @@ export const ForgotPasswordModal = ({ onClose }: ForgotPasswordModalProps) => {
           ) : (
             <button
               type="button"
-              className="btn btn-outline-secondary forgot-password-modal__btn mt-3"
+              className="forgot-modal__close-btn"
               onClick={onClose}
             >
               Cerrar

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.css
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.css
@@ -1,69 +1,159 @@
-.login-form {
-  max-width: 400px;
+/* ── Auth Form: shared visual style (login & register) ── */
+.auth-form {
   width: 100%;
 }
 
-.login-form__error {
-  color: var(--bs-danger);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
+/* ── Field group ── */
+.auth-form__field {
+  margin-bottom: 1rem;
 }
 
-.login-form__success {
-  color: var(--bs-success);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
+.auth-form__label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--brand-dark);
 }
 
-.login-form__input:focus {
-  border-color: var(--bs-primary);
-  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
-}
-
-.login-form__btn {
+.auth-form__input {
+  display: block;
   width: 100%;
-  padding: 0.75rem;
-  font-weight: 500;
+  padding: 0.6rem 0.85rem;
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  color: var(--brand-dark);
+  background-color: var(--brand-white);
+  border: 1.5px solid var(--auth-input-border);
+  border-radius: var(--auth-input-radius);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
 }
 
-.login-form__btn:disabled {
+.auth-form__input::placeholder {
+  color: var(--puch-silver);
+}
+
+.auth-form__input:focus {
+  border-color: var(--auth-input-focus);
+  box-shadow: 0 0 0 3px rgba(13, 59, 115, 0.12);
+}
+
+.auth-form__input:disabled {
+  opacity: 0.6;
   cursor: not-allowed;
-  opacity: 0.65;
 }
 
-.login-form__switch {
-  color: var(--bs-secondary);
-  font-size: 0.95rem;
+/* ── Submit button spacing ── */
+.auth-form__submit {
+  margin-top: 0.6rem;
 }
 
-.login-form__switch-link {
-  font-size: inherit;
-  text-decoration: none;
+/* ── Feedback (error / success) ── */
+.auth-form__feedback {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.4;
 }
 
-.login-form__divider {
+.auth-form__feedback--error {
+  color: var(--auth-feedback-error);
+  background-color: var(--auth-feedback-bg-error);
+}
+
+.auth-form__feedback--success {
+  color: var(--auth-feedback-success);
+  background-color: var(--auth-feedback-bg-success);
+}
+
+/* ── Divider ── */
+.auth-form__divider {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-top: 1.25rem;
-  color: var(--bs-secondary);
-  font-size: 0.875rem;
+  margin: 1.25rem 0;
+  color: var(--brand-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
-.login-form__divider::before,
-.login-form__divider::after {
+.auth-form__divider::before,
+.auth-form__divider::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+  border-bottom: 1px solid var(--auth-input-border);
 }
 
-.login-form__google {
-  margin-top: 1rem;
+/* ── Google button wrapper ── */
+.auth-form__google {
   display: flex;
   justify-content: center;
 }
 
-.login-form__google--disabled {
+.auth-form__google--disabled {
   pointer-events: none;
-  opacity: 0.65;
+  opacity: 0.55;
+}
+
+/* ── Forgot password ── */
+.auth-form__forgot {
+  margin: 0.9rem 0 0;
+  text-align: center;
+}
+
+.auth-form__forgot-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--brand-muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.auth-form__forgot-link:hover,
+.auth-form__forgot-link:focus {
+  color: var(--brand-secondary);
+  text-decoration: underline;
+}
+
+.auth-form__forgot-link:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ── Switch (link to register/login) ── */
+.auth-form__switch {
+  margin: 1.1rem 0 0;
+  font-size: 0.9rem;
+  color: var(--brand-muted);
+  text-align: center;
+}
+
+.auth-form__switch-link {
+  color: var(--brand-secondary);
+  font-weight: 700;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.auth-form__switch-link:hover,
+.auth-form__switch-link:focus {
+  color: var(--brand-primary);
+  text-decoration: underline;
+}
+
+.auth-form__switch-link:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+  border-radius: 2px;
 }

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -216,6 +216,7 @@ export const LoginForm = () => {
   };
 
   return (
+    <>
     <form className="auth-form" onSubmit={handleSubmit} noValidate>
       <div className="auth-form__field">
         <label htmlFor="email" className="auth-form__label">
@@ -321,10 +322,11 @@ export const LoginForm = () => {
           Regístrate
         </Link>
       </p>
-
-      {showForgotModal && (
-        <ForgotPasswordModal onClose={() => setShowForgotModal(false)} />
-      )}
     </form>
+
+    {showForgotModal && (
+      <ForgotPasswordModal onClose={() => setShowForgotModal(false)} />
+    )}
+  </>
   );
 };

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -216,14 +216,14 @@ export const LoginForm = () => {
   };
 
   return (
-    <form className="login-form" onSubmit={handleSubmit} noValidate>
-      <div className="mb-3">
-        <label htmlFor="email" className="form-label">
+    <form className="auth-form" onSubmit={handleSubmit} noValidate>
+      <div className="auth-form__field">
+        <label htmlFor="email" className="auth-form__label">
           Correo electrónico
         </label>
         <input
           type="email"
-          className="form-control login-form__input"
+          className="auth-form__input"
           id="email"
           name="email"
           value={formState.email}
@@ -235,13 +235,13 @@ export const LoginForm = () => {
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="password" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="password" className="auth-form__label">
           Contraseña
         </label>
         <input
           type="password"
-          className="form-control login-form__input"
+          className="auth-form__input"
           id="password"
           name="password"
           value={formState.password}
@@ -254,20 +254,22 @@ export const LoginForm = () => {
       </div>
 
       {formState.successMessage && (
-        <div className="login-form__success" role="status">
+        <div className="auth-form__feedback auth-form__feedback--success" role="status">
+          <i className="bi bi-check-circle-fill" aria-hidden="true"></i>
           {formState.successMessage}
         </div>
       )}
 
       {formState.error && (
-        <div className="login-form__error" role="alert">
+        <div className="auth-form__feedback auth-form__feedback--error" role="alert">
+          <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
           {formState.error}
         </div>
       )}
 
       <button
         type="submit"
-        className="btn btn-primary login-form__btn mt-3"
+        className="btn-brand-auth auth-form__submit"
         disabled={formState.loading}
       >
         {formState.loading ? (
@@ -277,47 +279,45 @@ export const LoginForm = () => {
               role="status"
               aria-hidden="true"
             ></span>
-            Entrando...
+            Entrando…
           </>
         ) : (
           'Entrar'
         )}
       </button>
 
-      <div className="login-form__divider" role="separator" aria-label="Otras opciones">
+      <div className="auth-form__divider" role="separator" aria-label="Otras opciones">
         <span>o</span>
       </div>
 
       <div
-        className={`login-form__google ${
-          formState.loading ? 'login-form__google--disabled' : ''
+        className={`auth-form__google ${
+          formState.loading ? 'auth-form__google--disabled' : ''
         }`}
       >
         <div ref={googleButtonRef} />
       </div>
 
       {googleError && (
-        <div className="login-form__error mt-2" role="alert">
+        <div className="auth-form__feedback auth-form__feedback--error mt-2" role="alert">
+          <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
           {googleError}
         </div>
       )}
 
-      <p className="text-center mt-3 mb-0">
+      <p className="auth-form__forgot">
         <button
           type="button"
-          className="btn btn-link p-0 login-form__switch-link"
+          className="auth-form__forgot-link"
           onClick={() => setShowForgotModal(true)}
         >
           ¿Olvidaste tu contraseña?
         </button>
       </p>
 
-      <p className="login-form__switch mt-2 mb-0 text-center">
+      <p className="auth-form__switch">
         ¿No estás registrado?{' '}
-        <Link
-          to="/auth/register"
-          className="btn btn-link p-0 align-baseline login-form__switch-link"
-        >
+        <Link to="/auth/register" className="auth-form__switch-link">
           Regístrate
         </Link>
       </p>

--- a/frontend/src/features/auth/components/RegisterForm/RegisterForm.css
+++ b/frontend/src/features/auth/components/RegisterForm/RegisterForm.css
@@ -1,42 +1,5 @@
-.register-form {
-  max-width: 400px;
-  width: 100%;
-}
-
-.register-form__error {
-  color: var(--bs-danger);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-}
-
-.register-form__success {
-  color: var(--bs-success);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-}
-
-.register-form__input:focus {
-  border-color: var(--bs-primary);
-  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
-}
-
-.register-form__btn {
-  width: 100%;
-  padding: 0.75rem;
-  font-weight: 500;
-}
-
-.register-form__btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-}
-
-.register-form__switch {
-  color: var(--bs-secondary);
-  font-size: 0.95rem;
-}
-
-.register-form__switch-link {
-  font-size: inherit;
-  text-decoration: none;
-}
+/*
+  RegisterForm comparte las clases .auth-form__* definidas en LoginForm.css.
+  Este archivo se mantiene para overrides específicos del formulario de registro
+  si fueran necesarios en el futuro.
+*/

--- a/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
@@ -109,50 +109,50 @@ export const RegisterForm = () => {
   };
 
   return (
-    <form className="register-form" onSubmit={handleSubmit} noValidate>
-      <div className="mb-3">
-        <label htmlFor="name" className="form-label">
+    <form className="auth-form" onSubmit={handleSubmit} noValidate>
+      <div className="auth-form__field">
+        <label htmlFor="name" className="auth-form__label">
           Nombre
         </label>
         <input
           type="text"
-          className="form-control register-form__input"
+          className="auth-form__input"
           id="name"
           name="name"
           value={formState.name}
           onChange={handleChange}
-          placeholder="Escribe tu nombre..."
+          placeholder="Escribe tu nombre…"
           disabled={formState.loading}
           required
           autoComplete="given-name"
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="surname" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="surname" className="auth-form__label">
           Apellidos
         </label>
         <input
           type="text"
-          className="form-control register-form__input"
+          className="auth-form__input"
           id="surname"
           name="surname"
           value={formState.surname}
           onChange={handleChange}
-          placeholder="Escribe tus apellidos..."
+          placeholder="Escribe tus apellidos…"
           disabled={formState.loading}
           required
           autoComplete="family-name"
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="register-email" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="register-email" className="auth-form__label">
           Correo electrónico
         </label>
         <input
           type="email"
-          className="form-control register-form__input"
+          className="auth-form__input"
           id="register-email"
           name="email"
           value={formState.email}
@@ -164,13 +164,13 @@ export const RegisterForm = () => {
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="register-password" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="register-password" className="auth-form__label">
           Contraseña
         </label>
         <input
           type="password"
-          className="form-control register-form__input"
+          className="auth-form__input"
           id="register-password"
           name="password"
           value={formState.password}
@@ -182,13 +182,13 @@ export const RegisterForm = () => {
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="confirmPassword" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="confirmPassword" className="auth-form__label">
           Confirmar contraseña
         </label>
         <input
           type="password"
-          className="form-control register-form__input"
+          className="auth-form__input"
           id="confirmPassword"
           name="confirmPassword"
           value={formState.confirmPassword}
@@ -201,20 +201,22 @@ export const RegisterForm = () => {
       </div>
 
       {formState.successMessage && (
-        <div className="register-form__success" role="status">
+        <div className="auth-form__feedback auth-form__feedback--success" role="status">
+          <i className="bi bi-check-circle-fill" aria-hidden="true"></i>
           {formState.successMessage}
         </div>
       )}
 
       {formState.error && (
-        <div className="register-form__error" role="alert">
+        <div className="auth-form__feedback auth-form__feedback--error" role="alert">
+          <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
           {formState.error}
         </div>
       )}
 
       <button
         type="submit"
-        className="btn btn-primary register-form__btn mt-3"
+        className="btn-brand-auth auth-form__submit"
         disabled={formState.loading}
       >
         {formState.loading ? (
@@ -224,19 +226,16 @@ export const RegisterForm = () => {
               role="status"
               aria-hidden="true"
             ></span>
-            Registrando...
+            Registrando…
           </>
         ) : (
           'Crear cuenta'
         )}
       </button>
 
-      <p className="register-form__switch mt-3 mb-0 text-center">
+      <p className="auth-form__switch">
         ¿Ya tienes cuenta?{' '}
-        <Link
-          to="/auth/login"
-          className="btn btn-link p-0 align-baseline register-form__switch-link"
-        >
+        <Link to="/auth/login" className="auth-form__switch-link">
           Inicia sesión
         </Link>
       </p>

--- a/frontend/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.css
+++ b/frontend/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.css
@@ -1,42 +1,4 @@
-.reset-password-form {
-  max-width: 400px;
-  width: 100%;
-}
-
-.reset-password-form__error {
-  color: var(--bs-danger);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-}
-
-.reset-password-form__success {
-  color: var(--bs-success);
-  font-size: 0.875rem;
-  margin-top: 0.5rem;
-}
-
-.reset-password-form__input:focus {
-  border-color: var(--bs-primary);
-  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
-}
-
-.reset-password-form__btn {
-  width: 100%;
-  padding: 0.75rem;
-  font-weight: 500;
-}
-
-.reset-password-form__btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.65;
-}
-
-.reset-password-form__switch {
-  color: var(--bs-secondary);
-  font-size: 0.95rem;
-}
-
-.reset-password-form__switch-link {
-  font-size: inherit;
-  text-decoration: none;
-}
+/*
+  ResetPasswordForm comparte las clases .auth-form__* definidas en LoginForm.css.
+  Este archivo se mantiene para overrides específicos si fueran necesarios.
+*/

--- a/frontend/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/features/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -99,14 +99,14 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
   };
 
   return (
-    <form className="reset-password-form" onSubmit={handleSubmit} noValidate>
-      <div className="mb-3">
-        <label htmlFor="newPassword" className="form-label">
+    <form className="auth-form" onSubmit={handleSubmit} noValidate>
+      <div className="auth-form__field">
+        <label htmlFor="newPassword" className="auth-form__label">
           Nueva contraseña
         </label>
         <input
           type="password"
-          className="form-control reset-password-form__input"
+          className="auth-form__input"
           id="newPassword"
           name="newPassword"
           value={formState.newPassword}
@@ -119,13 +119,13 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
         />
       </div>
 
-      <div className="mb-3">
-        <label htmlFor="confirmPassword" className="form-label">
+      <div className="auth-form__field">
+        <label htmlFor="confirmPassword" className="auth-form__label">
           Confirmar contraseña
         </label>
         <input
           type="password"
-          className="form-control reset-password-form__input"
+          className="auth-form__input"
           id="confirmPassword"
           name="confirmPassword"
           value={formState.confirmPassword}
@@ -139,13 +139,15 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
       </div>
 
       {formState.successMessage && (
-        <div className="reset-password-form__success" role="status">
-          {formState.successMessage}. Redirigiendo al login...
+        <div className="auth-form__feedback auth-form__feedback--success" role="status">
+          <i className="bi bi-check-circle-fill" aria-hidden="true"></i>
+          {formState.successMessage}. Redirigiendo al login…
         </div>
       )}
 
       {formState.error && (
-        <div className="reset-password-form__error" role="alert">
+        <div className="auth-form__feedback auth-form__feedback--error" role="alert">
+          <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
           {formState.error}
         </div>
       )}
@@ -153,7 +155,7 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
       {!formState.successMessage && (
         <button
           type="submit"
-          className="btn btn-primary reset-password-form__btn mt-3"
+          className="btn-brand-auth auth-form__submit"
           disabled={
             formState.loading ||
             !formState.newPassword ||
@@ -167,7 +169,7 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
                 role="status"
                 aria-hidden="true"
               ></span>
-              Guardando...
+              Guardando…
             </>
           ) : (
             'Restablecer contraseña'
@@ -175,11 +177,8 @@ export const ResetPasswordForm = ({ token }: ResetPasswordFormProps) => {
         </button>
       )}
 
-      <p className="reset-password-form__switch mt-3 mb-0 text-center">
-        <Link
-          to="/auth/login"
-          className="btn btn-link p-0 align-baseline reset-password-form__switch-link"
-        >
+      <p className="auth-form__switch">
+        <Link to="/auth/login" className="auth-form__switch-link">
           Volver al login
         </Link>
       </p>

--- a/frontend/src/features/auth/pages/AuthPage/AuthPage.css
+++ b/frontend/src/features/auth/pages/AuthPage/AuthPage.css
@@ -1,28 +1,84 @@
-.login-page {
+/* ── Auth page layout ── */
+.auth-page {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--bs-light);
+  padding: 2rem 1rem;
+  background:
+    linear-gradient(
+      160deg,
+      rgba(107, 170, 117, 0.07) 0%,
+      rgba(13, 59, 115, 0.05) 50%,
+      rgba(244, 245, 247, 1) 100%
+    );
 }
 
-.login-page__card {
-  background: white;
-  border-radius: 0.5rem;
-  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-  padding: 2rem;
+.auth-page__container {
   width: 100%;
-  max-width: 450px;
+  max-width: 460px;
 }
 
-.login-page__title {
-  font-size: 1.75rem;
+/* ── Card ── */
+.auth-page__card {
+  background: var(--auth-card-bg);
+  border-radius: var(--auth-card-radius);
+  box-shadow: var(--auth-card-shadow);
+  padding: 2.2rem 2rem;
+}
+
+/* ── Back link ── */
+.auth-page__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.88rem;
   font-weight: 600;
-  color: var(--bs-dark);
-  margin-bottom: 0.5rem;
+  color: var(--brand-muted);
+  text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease;
 }
 
-.login-page__description {
-  color: var(--bs-secondary);
-  margin-bottom: 1.5rem;
+.auth-page__back:hover,
+.auth-page__back:focus {
+  color: var(--brand-secondary);
+  background-color: rgba(13, 59, 115, 0.06);
+}
+
+.auth-page__back:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+}
+
+/* ── Heading ── */
+.auth-page__title {
+  font-family: var(--font-heading);
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--brand-secondary);
+  text-align: center;
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.02em;
+}
+
+.auth-page__description {
+  font-size: 0.95rem;
+  color: var(--brand-muted);
+  text-align: center;
+  margin-bottom: 1.6rem;
+  line-height: 1.5;
+}
+
+/* ── Responsive ── */
+@media (max-width: 575.98px) {
+  .auth-page__card {
+    padding: 1.6rem 1.25rem;
+  }
+
+  .auth-page__title {
+    font-size: 1.35rem;
+  }
 }

--- a/frontend/src/features/auth/pages/AuthPage/AuthPage.tsx
+++ b/frontend/src/features/auth/pages/AuthPage/AuthPage.tsx
@@ -13,32 +13,24 @@ export const AuthPage = ({ mode }: AuthPageProps) => {
   const isLoginMode = mode === 'login';
 
   return (
-    <main className="login-page">
-      <div className="container">
-        <div className="row justify-content-center">
-          <div className="col-12 col-md-8 col-lg-6">
-            <div className="login-page__card">
-              <Link to="/" className="btn btn-link p-0 mb-3 text-decoration-none">
-                <i className="bi bi-arrow-left me-1"></i>
-                Volver
-              </Link>
+    <main className="auth-page">
+      <div className="auth-page__container">
+        <div className="auth-page__card reveal-up">
+          <Link to="/" className="auth-page__back">
+            <i className="bi bi-arrow-left" aria-hidden="true"></i>
+            Volver al inicio
+          </Link>
 
-              <h1 className="login-page__title text-center">
-                {isLoginMode ? 'Iniciar sesión' : 'Crear cuenta'}
-              </h1>
-              <p className="login-page__description text-center">
-                {isLoginMode
-                  ? 'Accede a tu cuenta para continuar'
-                  : 'Regístrate para acceder a la plataforma'}
-              </p>
+          <h1 className="auth-page__title">
+            {isLoginMode ? 'Iniciar sesión' : 'Crear cuenta'}
+          </h1>
+          <p className="auth-page__description">
+            {isLoginMode
+              ? 'Accede a tu cuenta del Equipo PUCH'
+              : 'Únete al Equipo PUCH y colabora con nosotros'}
+          </p>
 
-              {isLoginMode ? (
-                <LoginForm />
-              ) : (
-                <RegisterForm />
-              )}
-            </div>
-          </div>
+          {isLoginMode ? <LoginForm /> : <RegisterForm />}
         </div>
       </div>
     </main>

--- a/frontend/src/features/auth/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,43 +1,37 @@
 import { useSearchParams } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { ResetPasswordForm } from '../../components/ResetPasswordForm/ResetPasswordForm';
+import '../AuthPage/AuthPage.css';
 
 export const ResetPasswordPage = () => {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
 
   return (
-    <main className="login-page">
-      <div className="container">
-        <div className="row justify-content-center">
-          <div className="col-12 col-md-8 col-lg-6">
-            <div className="login-page__card">
-              <Link to="/auth/login" className="btn btn-link p-0 mb-3 text-decoration-none">
-                <i className="bi bi-arrow-left me-1"></i>
-                Volver al login
+    <main className="auth-page">
+      <div className="auth-page__container">
+        <div className="auth-page__card reveal-up">
+          <Link to="/auth/login" className="auth-page__back">
+            <i className="bi bi-arrow-left" aria-hidden="true"></i>
+            Volver al login
+          </Link>
+
+          <h1 className="auth-page__title">Restablecer contraseña</h1>
+          <p className="auth-page__description">
+            Introduce tu nueva contraseña
+          </p>
+
+          {token ? (
+            <ResetPasswordForm token={token} />
+          ) : (
+            <div className="auth-form__feedback auth-form__feedback--error">
+              <i className="bi bi-exclamation-circle-fill" aria-hidden="true"></i>
+              El enlace de recuperación no es válido. Falta el token.
+              <Link to="/auth/login" className="btn-brand-auth auth-form__submit" style={{ marginTop: '0.75rem' }}>
+                Ir al login
               </Link>
-
-              <h1 className="login-page__title text-center">
-                Restablecer contraseña
-              </h1>
-              <p className="login-page__description text-center">
-                Introduce tu nueva contraseña
-              </p>
-
-              {token ? (
-                <ResetPasswordForm token={token} />
-              ) : (
-                <div className="text-center">
-                  <p className="text-danger">
-                    El enlace de recuperación no es válido. Falta el token.
-                  </p>
-                  <Link to="/auth/login" className="btn btn-primary mt-2">
-                    Ir al login
-                  </Link>
-                </div>
-              )}
             </div>
-          </div>
+          )}
         </div>
       </div>
     </main>

--- a/frontend/src/styles/bootstrap-overrides.css
+++ b/frontend/src/styles/bootstrap-overrides.css
@@ -78,3 +78,41 @@
   color: var(--brand-white);
   background: linear-gradient(135deg, #438a55, #286d5b);
 }
+
+/* ── Auth button (formularios login/registro) ── */
+.btn-brand-auth {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 46px;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.65rem 1.2rem;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--brand-white);
+  background: linear-gradient(135deg, #4d9860, #2f7f6b);
+  box-shadow: 0 8px 18px rgba(39, 105, 70, 0.22);
+  transition: background 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  cursor: pointer;
+}
+
+.btn-brand-auth:hover,
+.btn-brand-auth:focus {
+  color: var(--brand-white);
+  background: linear-gradient(135deg, #438a55, #286d5b);
+  box-shadow: 0 6px 14px rgba(39, 105, 70, 0.30);
+}
+
+.btn-brand-auth:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+}
+
+.btn-brand-auth:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -20,9 +20,22 @@
   --brand-muted: #5d6470;
   --brand-bg: #f4f5f7;
   --brand-white: var(--puch-white);
+  --radius-sm: 0.5rem;
   --radius-md: 0.75rem;
   --radius-lg: 1.1rem;
   --shadow-soft: 0 14px 34px rgba(17, 74, 30, 0.12);
+
+  /* Auth / Formularios */
+  --auth-card-bg: var(--puch-white);
+  --auth-card-radius: var(--radius-lg);
+  --auth-card-shadow: 0 16px 40px rgba(13, 59, 115, 0.10);
+  --auth-input-border: #d1d5db;
+  --auth-input-focus: var(--puch-indigo);
+  --auth-input-radius: var(--radius-md);
+  --auth-feedback-success: #16a34a;
+  --auth-feedback-error: #dc2626;
+  --auth-feedback-bg-success: rgba(22, 163, 74, 0.08);
+  --auth-feedback-bg-error: rgba(220, 38, 38, 0.07);
 }
 
 * {


### PR DESCRIPTION
## Resumen

Refactor visual de los componentes de autenticación para alinearlos con el branding Equipo PUCH. Sin cambios de lógica backend ni de flujo de sesión.

## Cambios

- **Tokens CSS** (globals.css, bootstrap-overrides.css): nuevas variables para auth (card, input, feedback) y utilidad `btn-brand-auth`
- **Header CTAs**: `focus-visible`, transiciones y radios con tokens PUCH
- **AuthPage**: gradiente de fondo PUCH, card con sombra de marca, tipografía Sora, copy contextualizado
- **LoginForm / RegisterForm**: migrados a clases `auth-form__*` compartidas con inputs, feedback (iconos + fondo) y botón de marca
- **ForgotPasswordModal**: adaptado a tokens PUCH (card, inputs, feedback)
- **ResetPasswordForm / ResetPasswordPage**: migrados al layout `auth-page__*`
- **Fix**: movido `ForgotPasswordModal` fuera del `<form>` de login para resolver bug de form anidado que impedía el envío
