### PR TITLE
HU-37: Gestión de Delegaciones (Admin)

### DIFF
--- a/backend/prisma/migrations/20260318170000_add_regions_admin_hu37/migration.sql
+++ b/backend/prisma/migrations/20260318170000_add_regions_admin_hu37/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Region" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Region_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Region_name_key" ON "Region"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Region_email_key" ON "Region"("email");
+
+-- CreateIndex
+CREATE INDEX "Region_deletedAt_idx" ON "Region"("deletedAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -80,3 +80,15 @@ model Superhero {
 
   createdBy User @relation(fields: [createdById], references: [id])
 }
+
+model Region {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  address   String
+  email     String   @unique
+  deletedAt DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([deletedAt])
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { NewsModule } from './news/news.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { RegionsModule } from './regions/regions.module';
 import { SuperheroesModule } from './superheroes/superheroes.module';
 import { UsersModule } from './users/users.module';
 
@@ -16,6 +17,7 @@ import { UsersModule } from './users/users.module';
     PrismaModule,
     UsersModule,
     NewsModule,
+    RegionsModule,
     SuperheroesModule,
   ],
   controllers: [],

--- a/backend/src/regions/admin-regions.controller.ts
+++ b/backend/src/regions/admin-regions.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt_strategy/jwt-auth.guard';
+import { Roles } from '../auth/roles/roles.decorator';
+import { RolesGuard } from '../auth/roles/roles.guard';
+import { RoleName } from '../common/types/role-name.enum';
+import { CreateRegionDto } from './dto/create-region.dto';
+import { ListRegionsQueryDto } from './dto/list-regions-query.dto';
+import { UpdateRegionDto } from './dto/update-region.dto';
+import { RegionsService } from './regions.service';
+
+@Controller('admin/regions')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(RoleName.ADMIN)
+export class AdminRegionsController {
+  constructor(private readonly regionsService: RegionsService) {}
+
+  @Get()
+  findAll(@Query() query: ListRegionsQueryDto) {
+    return this.regionsService.findAllForAdmin(query);
+  }
+
+  @Post()
+  create(@Body() createRegionDto: CreateRegionDto) {
+    return this.regionsService.create(createRegionDto);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateRegionDto: UpdateRegionDto,
+  ) {
+    return this.regionsService.update(id, updateRegionDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.regionsService.remove(id);
+  }
+}

--- a/backend/src/regions/dto/create-region.dto.ts
+++ b/backend/src/regions/dto/create-region.dto.ts
@@ -1,0 +1,20 @@
+import { IsEmail, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateRegionDto {
+  @IsString()
+  @IsNotEmpty({ message: 'El nombre es obligatorio' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(100, { message: 'El nombre no puede superar 100 caracteres' })
+  name: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'La dirección es obligatoria' })
+  @MinLength(6, { message: 'La dirección debe tener al menos 6 caracteres' })
+  @MaxLength(200, { message: 'La dirección no puede superar 200 caracteres' })
+  address: string;
+
+  @IsEmail({}, { message: 'El email no es válido' })
+  @IsNotEmpty({ message: 'El email es obligatorio' })
+  @MaxLength(120, { message: 'El email no puede superar 120 caracteres' })
+  email: string;
+}

--- a/backend/src/regions/dto/list-regions-query.dto.ts
+++ b/backend/src/regions/dto/list-regions-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ListRegionsQueryDto {
+  @IsOptional()
+  @IsString({ message: 'El criterio de búsqueda debe ser texto' })
+  @MaxLength(120, { message: 'El criterio de búsqueda es demasiado largo' })
+  search?: string;
+}

--- a/backend/src/regions/dto/update-region.dto.ts
+++ b/backend/src/regions/dto/update-region.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateRegionDto } from './create-region.dto';
+
+export class UpdateRegionDto extends PartialType(CreateRegionDto) {}

--- a/backend/src/regions/regions.module.ts
+++ b/backend/src/regions/regions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AdminRegionsController } from './admin-regions.controller';
+import { RegionsService } from './regions.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [AdminRegionsController],
+  providers: [RegionsService],
+})
+export class RegionsModule {}

--- a/backend/src/regions/regions.service.ts
+++ b/backend/src/regions/regions.service.ts
@@ -1,0 +1,172 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, type Region } from 'generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRegionDto } from './dto/create-region.dto';
+import { ListRegionsQueryDto } from './dto/list-regions-query.dto';
+import { UpdateRegionDto } from './dto/update-region.dto';
+
+type RegionWithBooksCount = Region & {
+  booksCount: number;
+};
+
+@Injectable()
+export class RegionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAllForAdmin(query: ListRegionsQueryDto): Promise<RegionWithBooksCount[]> {
+    const where: Prisma.RegionWhereInput = {
+      deletedAt: null,
+    };
+
+    const searchTerm = query.search?.trim();
+    if (searchTerm) {
+      where.OR = [
+        {
+          name: {
+            contains: searchTerm,
+            mode: 'insensitive',
+          },
+        },
+        {
+          email: {
+            contains: searchTerm,
+            mode: 'insensitive',
+          },
+        },
+      ];
+    }
+
+    const regions = await this.prisma.region.findMany({
+      where,
+      orderBy: {
+        name: 'asc',
+      },
+    });
+
+    return regions.map((region) => ({
+      ...region,
+      booksCount: 0,
+    }));
+  }
+
+  async create(createRegionDto: CreateRegionDto) {
+    try {
+      const region = await this.prisma.region.create({
+        data: {
+          name: createRegionDto.name.trim(),
+          address: createRegionDto.address.trim(),
+          email: createRegionDto.email.trim().toLowerCase(),
+        },
+      });
+
+      return {
+        message: 'Delegación creada correctamente',
+        region: {
+          ...region,
+          booksCount: 0,
+        },
+      };
+    } catch (error) {
+      this.handleUniqueConstraint(error);
+      throw error;
+    }
+  }
+
+  async update(id: number, updateRegionDto: UpdateRegionDto) {
+    await this.findActiveById(id);
+
+    const updateData: Prisma.RegionUpdateInput = {};
+
+    if (updateRegionDto.name !== undefined) {
+      updateData.name = updateRegionDto.name.trim();
+    }
+
+    if (updateRegionDto.address !== undefined) {
+      updateData.address = updateRegionDto.address.trim();
+    }
+
+    if (updateRegionDto.email !== undefined) {
+      updateData.email = updateRegionDto.email.trim().toLowerCase();
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      throw new BadRequestException(
+        'Debes enviar al menos un campo para actualizar',
+      );
+    }
+
+    try {
+      const region = await this.prisma.region.update({
+        where: { id },
+        data: updateData,
+      });
+
+      return {
+        message: 'Delegación actualizada correctamente',
+        region: {
+          ...region,
+          booksCount: 0,
+        },
+      };
+    } catch (error) {
+      this.handleUniqueConstraint(error);
+      throw error;
+    }
+  }
+
+  async remove(id: number) {
+    await this.findActiveById(id);
+
+    await this.prisma.region.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+
+    return {
+      message: 'Delegación eliminada correctamente',
+    };
+  }
+
+  private async findActiveById(id: number): Promise<Region> {
+    const region = await this.prisma.region.findFirst({
+      where: {
+        id,
+        deletedAt: null,
+      },
+    });
+
+    if (!region) {
+      throw new NotFoundException(`Delegación con id ${id} no encontrada`);
+    }
+
+    return region;
+  }
+
+  private handleUniqueConstraint(error: unknown) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      const target = Array.isArray(error.meta?.target)
+        ? error.meta.target.join(', ')
+        : '';
+
+      if (target.includes('name')) {
+        throw new ConflictException('Ya existe una delegación con ese nombre');
+      }
+
+      if (target.includes('email')) {
+        throw new ConflictException('Ya existe una delegación con ese email');
+      }
+
+      throw new ConflictException('Ya existe una delegación con esos datos');
+    }
+  }
+}

--- a/frontend/src/features/admin/api/regions.api.ts
+++ b/frontend/src/features/admin/api/regions.api.ts
@@ -1,0 +1,58 @@
+import type { AxiosResponse } from 'axios';
+import api from '../../../services/http/axios.instance';
+import type { ApiResponse } from '../../../types/api';
+import { getAuthSession } from '../../auth/utils/auth-session.storage';
+import type {
+  AdminRegion,
+  CreateRegionPayload,
+  UpdateRegionPayload,
+} from '../types/regions.types';
+
+const authHeaders = () => {
+  const token = getAuthSession().accessToken;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const handleResponse = <T>(response: AxiosResponse<ApiResponse<T>>) => response.data;
+
+export const listRegions = async (search?: string) => {
+  const response = await api.get<ApiResponse<AdminRegion[]>>('/admin/regions', {
+    headers: authHeaders(),
+    params: search?.trim() ? { search: search.trim() } : {},
+  });
+
+  return handleResponse(response);
+};
+
+export const createRegion = async (payload: CreateRegionPayload) => {
+  const response = await api.post<ApiResponse<{ region: AdminRegion }>>(
+    '/admin/regions',
+    payload,
+    {
+      headers: authHeaders(),
+    },
+  );
+
+  return handleResponse(response);
+};
+
+export const updateRegion = async (payload: UpdateRegionPayload) => {
+  const { id, ...body } = payload;
+  const response = await api.patch<ApiResponse<{ region: AdminRegion }>>(
+    `/admin/regions/${id}`,
+    body,
+    {
+      headers: authHeaders(),
+    },
+  );
+
+  return handleResponse(response);
+};
+
+export const deleteRegion = async (id: number) => {
+  const response = await api.delete<ApiResponse<null>>(`/admin/regions/${id}`, {
+    headers: authHeaders(),
+  });
+
+  return handleResponse(response);
+};

--- a/frontend/src/features/admin/components/regions/RegionCard/RegionCard.css
+++ b/frontend/src/features/admin/components/regions/RegionCard/RegionCard.css
@@ -1,0 +1,78 @@
+.region-card {
+  background: #fff;
+  border: 1px solid rgba(18, 36, 71, 0.08);
+  border-radius: 1rem;
+  box-shadow: 0 10px 24px rgba(15, 52, 110, 0.09);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.region-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.region-card__header h3 {
+  margin: 0;
+  color: #122447;
+  font-size: 1.05rem;
+}
+
+.region-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(13, 59, 115, 0.12);
+  color: #0d3b73;
+  font-size: 0.77rem;
+  font-weight: 700;
+  padding: 0.22rem 0.65rem;
+}
+
+.region-card__details {
+  margin: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.region-card__details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #617084;
+}
+
+.region-card__details dd {
+  margin: 0.15rem 0 0;
+  color: #23384f;
+  word-break: break-word;
+}
+
+.region-card__actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: auto;
+}
+
+.region-card__action {
+  border: none;
+  border-radius: 999px;
+  padding: 0.42rem 0.85rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.region-card__action--edit {
+  background: rgba(13, 59, 115, 0.12);
+  color: #0d3b73;
+}
+
+.region-card__action--delete {
+  background: rgba(138, 31, 47, 0.14);
+  color: #8a1f2f;
+}

--- a/frontend/src/features/admin/components/regions/RegionCard/RegionCard.tsx
+++ b/frontend/src/features/admin/components/regions/RegionCard/RegionCard.tsx
@@ -1,0 +1,47 @@
+import type { AdminRegion } from '../../../types/regions.types';
+import './RegionCard.css';
+
+type RegionCardProps = {
+  region: AdminRegion;
+  onEdit: (region: AdminRegion) => void;
+  onDelete: (region: AdminRegion) => void;
+};
+
+export const RegionCard = ({ region, onEdit, onDelete }: RegionCardProps) => (
+  <article className="region-card">
+    <header className="region-card__header">
+      <h3>{region.name}</h3>
+      <span className="region-card__badge">
+        {region.booksCount} {region.booksCount === 1 ? 'libro' : 'libros'}
+      </span>
+    </header>
+
+    <dl className="region-card__details">
+      <div>
+        <dt>Dirección</dt>
+        <dd>{region.address}</dd>
+      </div>
+      <div>
+        <dt>Email</dt>
+        <dd>{region.email}</dd>
+      </div>
+    </dl>
+
+    <div className="region-card__actions">
+      <button
+        type="button"
+        onClick={() => onEdit(region)}
+        className="region-card__action region-card__action--edit"
+      >
+        Editar
+      </button>
+      <button
+        type="button"
+        onClick={() => onDelete(region)}
+        className="region-card__action region-card__action--delete"
+      >
+        Eliminar
+      </button>
+    </div>
+  </article>
+);

--- a/frontend/src/features/admin/components/regions/RegionForm/RegionForm.css
+++ b/frontend/src/features/admin/components/regions/RegionForm/RegionForm.css
@@ -1,0 +1,127 @@
+.region-form-card {
+  background: #fff;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(215, 187, 152, 0.6);
+  padding: 1rem;
+  box-shadow: 0 18px 35px rgba(15, 52, 110, 0.12);
+}
+
+.region-form-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.8rem;
+  margin-bottom: 0.9rem;
+}
+
+.region-form-card__eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  color: #6b5d4c;
+  text-transform: uppercase;
+}
+
+.region-form-card__header h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1.25rem;
+  color: var(--brand-dark);
+}
+
+.region-form-card__close {
+  border-radius: 999px;
+  border: 1px solid rgba(13, 59, 115, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--brand-secondary);
+  padding: 0.38rem 0.8rem;
+  font-weight: 600;
+}
+
+.region-form-card__feedback {
+  margin: 0 0 0.9rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 225, 181, 0.5);
+  color: #6b5d4c;
+  font-weight: 600;
+}
+
+.region-form-card__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.region-form-card__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.83rem;
+  color: #53443a;
+  font-weight: 600;
+}
+
+.region-form-card__form input {
+  border: 1px solid rgba(207, 207, 207, 0.9);
+  border-radius: 0.72rem;
+  padding: 0.58rem 0.8rem;
+  font-size: 0.93rem;
+  font-family: inherit;
+  background: #fff;
+}
+
+.region-form-card__form input:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 2px rgba(107, 170, 117, 0.2);
+}
+
+.region-form-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.2rem;
+}
+
+.region-form-card__primary {
+  min-width: 170px;
+}
+
+.region-form-card__secondary {
+  min-width: 140px;
+}
+
+.region-form-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 4vh;
+  z-index: 999;
+}
+
+.region-form-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 52, 93, 0.45);
+  backdrop-filter: blur(3px);
+}
+
+.region-form-modal__content {
+  position: relative;
+  width: min(560px, 90vw);
+  margin: 0 1rem;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .region-form-card__actions {
+    flex-direction: column;
+  }
+
+  .region-form-modal__content {
+    width: min(560px, 94vw);
+    margin: 0 0.5rem;
+  }
+}

--- a/frontend/src/features/admin/components/regions/RegionForm/RegionForm.tsx
+++ b/frontend/src/features/admin/components/regions/RegionForm/RegionForm.tsx
@@ -1,0 +1,119 @@
+import type { FormEvent } from 'react';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import type { RegionFormData } from '../../../types/regions.types';
+import './RegionForm.css';
+
+type RegionFormProps = {
+  isOpen: boolean;
+  formMode: 'create' | 'edit';
+  formData: RegionFormData;
+  feedback?: string | null;
+  isProcessing: boolean;
+  onFieldChange: (field: keyof RegionFormData, value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onReset: () => void;
+  onClose: () => void;
+};
+
+export const RegionForm = ({
+  isOpen,
+  formMode,
+  formData,
+  feedback,
+  isProcessing,
+  onFieldChange,
+  onSubmit,
+  onReset,
+  onClose,
+}: RegionFormProps) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="region-form-modal" role="dialog" aria-modal="true">
+      <div className="region-form-modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="region-form-modal__content">
+        <div className="region-form-card">
+          <div className="region-form-card__header">
+            <div>
+              <p className="region-form-card__eyebrow">Gestión de delegaciones</p>
+              <h2>{formMode === 'create' ? 'Nueva delegación' : 'Editar delegación'}</h2>
+            </div>
+            <button type="button" className="region-form-card__close" onClick={onClose}>
+              Cerrar
+            </button>
+          </div>
+
+          {feedback ? <p className="region-form-card__feedback">{feedback}</p> : null}
+
+          <form className="region-form-card__form" onSubmit={onSubmit}>
+            <label>
+              Nombre
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(event) => onFieldChange('name', event.target.value)}
+                placeholder="Cantabria"
+                maxLength={100}
+                required
+              />
+            </label>
+
+            <label>
+              Dirección
+              <input
+                type="text"
+                value={formData.address}
+                onChange={(event) => onFieldChange('address', event.target.value)}
+                placeholder="Calle, número, ciudad"
+                maxLength={200}
+                required
+              />
+            </label>
+
+            <label>
+              Email
+              <input
+                type="email"
+                value={formData.email}
+                onChange={(event) => onFieldChange('email', event.target.value)}
+                placeholder="delegacion@proclade.org"
+                maxLength={120}
+                required
+              />
+            </label>
+
+            <div className="region-form-card__actions">
+              <AdminButton
+                type="submit"
+                variant="solid"
+                className="region-form-card__primary"
+                loading={isProcessing}
+                disabled={
+                  !formData.name.trim() ||
+                  !formData.address.trim() ||
+                  !formData.email.trim()
+                }
+              >
+                {isProcessing
+                  ? 'Guardando...'
+                  : formMode === 'create'
+                    ? 'Crear delegación'
+                    : 'Guardar cambios'}
+              </AdminButton>
+              <AdminButton
+                variant="outline"
+                className="region-form-card__secondary"
+                onClick={onReset}
+                type="button"
+              >
+                Limpiar
+              </AdminButton>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/regions/RegionsGrid/RegionsGrid.css
+++ b/frontend/src/features/admin/components/regions/RegionsGrid/RegionsGrid.css
@@ -1,0 +1,13 @@
+.regions-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.regions-grid--empty {
+  border: 1px dashed rgba(13, 59, 115, 0.28);
+  border-radius: 0.9rem;
+  padding: 1.25rem;
+  color: #4a6079;
+  background: rgba(255, 255, 255, 0.65);
+}

--- a/frontend/src/features/admin/components/regions/RegionsGrid/RegionsGrid.tsx
+++ b/frontend/src/features/admin/components/regions/RegionsGrid/RegionsGrid.tsx
@@ -1,0 +1,32 @@
+import type { AdminRegion } from '../../../types/regions.types';
+import { RegionCard } from '../RegionCard/RegionCard';
+import './RegionsGrid.css';
+
+type RegionsGridProps = {
+  regions: AdminRegion[];
+  onEdit: (region: AdminRegion) => void;
+  onDelete: (region: AdminRegion) => void;
+};
+
+export const RegionsGrid = ({ regions, onEdit, onDelete }: RegionsGridProps) => {
+  if (!regions.length) {
+    return (
+      <div className="regions-grid regions-grid--empty">
+        No hay delegaciones para mostrar.
+      </div>
+    );
+  }
+
+  return (
+    <div className="regions-grid">
+      {regions.map((region) => (
+        <RegionCard
+          key={region.id}
+          region={region}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/regions/RegionsToolbar/RegionsToolbar.css
+++ b/frontend/src/features/admin/components/regions/RegionsToolbar/RegionsToolbar.css
@@ -1,0 +1,7 @@
+.regions-toolbar {
+  width: 100%;
+}
+
+.regions-toolbar__new {
+  min-width: 185px;
+}

--- a/frontend/src/features/admin/components/regions/RegionsToolbar/RegionsToolbar.tsx
+++ b/frontend/src/features/admin/components/regions/RegionsToolbar/RegionsToolbar.tsx
@@ -1,0 +1,37 @@
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import { AdminSearchBar } from '../../shared/AdminSearchBar/AdminSearchBar';
+import { AdminToolbar } from '../../shared/AdminToolbar/AdminToolbar';
+import './RegionsToolbar.css';
+
+type RegionsToolbarProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onNew: () => void;
+};
+
+export const RegionsToolbar = ({
+  search,
+  onSearchChange,
+  onNew,
+}: RegionsToolbarProps) => (
+  <div className="regions-toolbar">
+    <AdminToolbar
+      searchSlot={
+        <AdminSearchBar
+          value={search}
+          onChange={onSearchChange}
+          placeholder="Buscar por nombre o email..."
+        />
+      }
+      actionsSlot={
+        <AdminButton
+          variant="solid"
+          className="regions-toolbar__new"
+          onClick={onNew}
+        >
+          Nueva delegación
+        </AdminButton>
+      }
+    />
+  </div>
+);

--- a/frontend/src/features/admin/components/shared/AdminSidebar/AdminSidebar.css
+++ b/frontend/src/features/admin/components/shared/AdminSidebar/AdminSidebar.css
@@ -2,15 +2,16 @@
   width: 260px;
   background: linear-gradient(
     180deg,
-    var(--brand-primary) 0%,
-    #0a78c2 55%,
-    var(--brand-secondary) 100%
+    #6baa75 0%,
+    #4a9960 48%,
+    #2f7f6b 100%
   );
   color: var(--brand-white);
   display: flex;
   flex-direction: column;
   padding: 1rem;
-  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  border-right: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.08);
 }
 
 .admin-sidebar__brand {

--- a/frontend/src/features/admin/hooks/useRegionsList.ts
+++ b/frontend/src/features/admin/hooks/useRegionsList.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { listRegions } from '../api/regions.api';
+import type { AdminRegion } from '../types/regions.types';
+
+type UseRegionsListOptions = {
+  onError?: (message: string) => void;
+};
+
+const orderRegions = (regions: AdminRegion[]) =>
+  [...regions].sort((a, b) => a.name.localeCompare(b.name, 'es'));
+
+export const useRegionsList = ({ onError }: UseRegionsListOptions = {}) => {
+  const [regions, setRegions] = useState<AdminRegion[]>([]);
+  const [search, setSearch] = useState('');
+  const [isFetching, setIsFetching] = useState(false);
+
+  const refreshRegions = useCallback(async () => {
+    setIsFetching(true);
+    try {
+      const response = await listRegions();
+      if (response.success) {
+        setRegions(Array.isArray(response.data) ? response.data : []);
+        return;
+      }
+
+      onError?.(response.message || 'No se pudo cargar delegaciones.');
+    } catch {
+      onError?.('No se pudo actualizar la lista de delegaciones.');
+    } finally {
+      setIsFetching(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    refreshRegions();
+  }, [refreshRegions]);
+
+  const orderedRegions = useMemo(() => orderRegions(regions), [regions]);
+
+  const filteredRegions = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) {
+      return orderedRegions;
+    }
+
+    return orderedRegions.filter((region) =>
+      [region.name, region.email].some((field) =>
+        field.toLowerCase().includes(term),
+      ),
+    );
+  }, [orderedRegions, search]);
+
+  return {
+    filteredRegions,
+    isFetching,
+    refreshRegions,
+    search,
+    setSearch,
+  };
+};

--- a/frontend/src/features/admin/pages/AdminRegionsPage/AdminRegionsPage.css
+++ b/frontend/src/features/admin/pages/AdminRegionsPage/AdminRegionsPage.css
@@ -1,0 +1,92 @@
+.admin-regions-page {
+  background: #eef1f6;
+  border-radius: 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2.4rem);
+  box-shadow: 0 30px 60px rgba(15, 52, 110, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.admin-regions-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.admin-regions-page__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #51657e;
+}
+
+.admin-regions-page__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2.2rem);
+  color: #122447;
+}
+
+.admin-regions-page__description {
+  margin: 0;
+  max-width: 60ch;
+  color: #3f4f63;
+}
+
+.admin-regions-page__feedback {
+  margin: 0;
+  color: #5f3d00;
+  background: rgba(255, 193, 7, 0.15);
+  border: 1px solid rgba(255, 193, 7, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.admin-regions-page__state {
+  margin: 0;
+  color: #3f4f63;
+  font-weight: 600;
+}
+
+.regions-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #5d6470;
+}
+
+.regions-pagination__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.regions-pagination__controls button {
+  border: 1px solid rgba(13, 59, 115, 0.2);
+  background: #fff;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.regions-pagination__controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.regions-pagination__controls span {
+  min-width: 80px;
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .regions-pagination {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.55rem;
+  }
+}

--- a/frontend/src/features/admin/pages/AdminRegionsPage/AdminRegionsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminRegionsPage/AdminRegionsPage.tsx
@@ -1,0 +1,293 @@
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { createRegion, deleteRegion, updateRegion } from '../../api/regions.api';
+import { RegionForm } from '../../components/regions/RegionForm/RegionForm';
+import { RegionsGrid } from '../../components/regions/RegionsGrid/RegionsGrid';
+import { RegionsToolbar } from '../../components/regions/RegionsToolbar/RegionsToolbar';
+import { ConfirmModal } from '../../components/shared/ConfirmModal/ConfirmModal';
+import { useRegionsList } from '../../hooks/useRegionsList';
+import type {
+  AdminRegion,
+  CreateRegionPayload,
+  RegionFormData,
+} from '../../types/regions.types';
+import './AdminRegionsPage.css';
+
+const initialFormState: RegionFormData = {
+  name: '',
+  address: '',
+  email: '',
+};
+
+const validateRegionForm = (formData: RegionFormData): string | null => {
+  const name = formData.name.trim();
+  const address = formData.address.trim();
+  const email = formData.email.trim().toLowerCase();
+
+  if (name.length < 2) {
+    return 'El nombre debe tener al menos 2 caracteres.';
+  }
+
+  if (address.length < 6) {
+    return 'La dirección debe tener al menos 6 caracteres.';
+  }
+
+  if (!email.includes('@')) {
+    return 'El email no es válido.';
+  }
+
+  return null;
+};
+
+const buildRegionPayload = (formData: RegionFormData): CreateRegionPayload => ({
+  name: formData.name.trim(),
+  address: formData.address.trim(),
+  email: formData.email.trim().toLowerCase(),
+});
+
+export const AdminRegionsPage = () => {
+  const [formData, setFormData] = useState(initialFormState);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [selectedRegion, setSelectedRegion] = useState<AdminRegion | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [pendingDeleteRegion, setPendingDeleteRegion] = useState<AdminRegion | null>(
+    null,
+  );
+
+  const handleRegionError = useCallback(
+    (message: string) => setFeedback(message),
+    [],
+  );
+
+  const {
+    filteredRegions,
+    isFetching,
+    refreshRegions,
+    search,
+    setSearch,
+  } = useRegionsList({ onError: handleRegionError });
+
+  const rowsPerPage = 8;
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(filteredRegions.length / rowsPerPage));
+  const paginatedRegions = useMemo(
+    () =>
+      filteredRegions.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [filteredRegions, page, rowsPerPage],
+  );
+
+  useEffect(() => {
+    setPage(0);
+  }, [filteredRegions.length, search]);
+
+  useEffect(() => {
+    if (page >= totalPages) {
+      setPage(totalPages - 1);
+    }
+  }, [page, totalPages]);
+
+  const resetFormState = () => {
+    setFormData(initialFormState);
+    setFormMode('create');
+    setSelectedRegion(null);
+  };
+
+  const handleCreateRegion = () => {
+    resetFormState();
+    setFeedback(null);
+    setIsFormOpen(true);
+  };
+
+  const handleEditRegion = (region: AdminRegion) => {
+    setFormMode('edit');
+    setSelectedRegion(region);
+    setFormData({
+      name: region.name,
+      address: region.address,
+      email: region.email,
+    });
+    setFeedback(null);
+    setIsFormOpen(true);
+  };
+
+  const handleRequestDelete = (region: AdminRegion) => {
+    setPendingDeleteRegion(region);
+  };
+
+  const handleCancelDelete = () => {
+    setPendingDeleteRegion(null);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDeleteRegion) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setFeedback(null);
+
+    try {
+      const response = await deleteRegion(pendingDeleteRegion.id);
+      if (response.success) {
+        setFeedback(response.message || 'Delegación eliminada correctamente.');
+        await refreshRegions();
+      } else {
+        setFeedback(response.message || 'No se pudo eliminar la delegación.');
+      }
+    } catch {
+      setFeedback('No se pudo eliminar la delegación.');
+    } finally {
+      setIsProcessing(false);
+      setPendingDeleteRegion(null);
+    }
+  };
+
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    resetFormState();
+    setFeedback(null);
+  };
+
+  const handleResetForm = () => {
+    setFormData(initialFormState);
+    setFeedback(null);
+  };
+
+  const handleFieldChange = (field: keyof RegionFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFeedback(null);
+  };
+
+  const handleSubmitForm = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const validationError = validateRegionForm(formData);
+    if (validationError) {
+      setFeedback(validationError);
+      return;
+    }
+
+    if (formMode === 'edit' && !selectedRegion) {
+      setFeedback('Selecciona una delegación antes de editar.');
+      return;
+    }
+
+    setIsProcessing(true);
+    setFeedback(null);
+
+    try {
+      const payload = buildRegionPayload(formData);
+      const response =
+        formMode === 'create'
+          ? await createRegion(payload)
+          : await updateRegion({
+              id: selectedRegion!.id,
+              ...payload,
+            });
+
+      if (response.success) {
+        setFeedback(response.message || 'Operación realizada correctamente.');
+        await refreshRegions();
+        setIsFormOpen(false);
+        resetFormState();
+      } else {
+        setFeedback(response.message || 'No se pudo guardar la delegación.');
+      }
+    } catch {
+      setFeedback('Error al guardar la delegación.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <section className="admin-regions-page">
+      <RegionForm
+        isOpen={isFormOpen}
+        formMode={formMode}
+        formData={formData}
+        feedback={isFormOpen ? feedback : null}
+        isProcessing={isProcessing}
+        onFieldChange={handleFieldChange}
+        onSubmit={handleSubmitForm}
+        onReset={handleResetForm}
+        onClose={handleCloseForm}
+      />
+
+      <header className="admin-regions-page__header">
+        <p className="admin-regions-page__eyebrow">Panel de administración</p>
+        <h1 className="admin-regions-page__title">Gestión de delegaciones</h1>
+        <p className="admin-regions-page__description">
+          Administra nombre, contacto y visibilidad de delegaciones.
+        </p>
+      </header>
+
+      <RegionsToolbar
+        search={search}
+        onSearchChange={setSearch}
+        onNew={handleCreateRegion}
+      />
+
+      {feedback && !isFormOpen ? (
+        <p className="admin-regions-page__feedback" role="status">
+          {feedback}
+        </p>
+      ) : null}
+
+      {isFetching ? (
+        <p className="admin-regions-page__state">Cargando delegaciones...</p>
+      ) : null}
+
+      <RegionsGrid
+        regions={paginatedRegions}
+        onEdit={handleEditRegion}
+        onDelete={handleRequestDelete}
+      />
+
+      <div className="regions-pagination">
+        <div className="regions-pagination__info">
+          Mostrando {filteredRegions.length === 0 ? 0 : page * rowsPerPage + 1}-
+          {Math.min(filteredRegions.length, (page + 1) * rowsPerPage)} de{' '}
+          {filteredRegions.length}
+        </div>
+        <div className="regions-pagination__controls">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(0, prev - 1))}
+            disabled={page === 0}
+            aria-label="Página anterior"
+          >
+            ←
+          </button>
+          <span>
+            {page + 1} de {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.min(totalPages - 1, prev + 1))}
+            disabled={page >= totalPages - 1}
+            aria-label="Página siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+
+      <ConfirmModal
+        isOpen={Boolean(pendingDeleteRegion)}
+        title="Eliminar delegación"
+        description={
+          pendingDeleteRegion
+            ? `¿Quieres eliminar la delegación "${pendingDeleteRegion.name}"?`
+            : undefined
+        }
+        confirmLabel="Sí, eliminar"
+        cancelLabel="Cancelar"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        isProcessing={isProcessing}
+      />
+    </section>
+  );
+};

--- a/frontend/src/features/admin/types/regions.types.ts
+++ b/frontend/src/features/admin/types/regions.types.ts
@@ -1,0 +1,26 @@
+export type AdminRegion = {
+  id: number;
+  name: string;
+  address: string;
+  email: string;
+  booksCount: number;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateRegionPayload = {
+  name: string;
+  address: string;
+  email: string;
+};
+
+export type UpdateRegionPayload = Partial<CreateRegionPayload> & {
+  id: number;
+};
+
+export type RegionFormData = {
+  name: string;
+  address: string;
+  email: string;
+};

--- a/frontend/src/router/app.router.tsx
+++ b/frontend/src/router/app.router.tsx
@@ -5,6 +5,7 @@ import { ResetPasswordPage } from '../features/auth/pages/ResetPasswordPage/Rese
 import { AdminLayout } from '../features/admin/components/layout/AdminLayout/AdminLayout';
 import { AdminDashboardPage } from '../features/admin/pages/AdminDashboardPage/AdminDashboardPage';
 import { AdminNewsPage } from '../features/admin/pages/AdminNewsPage/AdminNewsPage';
+import { AdminRegionsPage } from '../features/admin/pages/AdminRegionsPage/AdminRegionsPage';
 import { AdminUsersPage } from '../features/admin/pages/AdminUsersPage/AdminUsersPage';
 import { AdminSectionPage } from '../features/admin/pages/AdminSectionPage/AdminSectionPage';
 import { PublicLayout } from './layouts/PublicLayout';
@@ -87,7 +88,7 @@ export const appRouter = createBrowserRouter([
       },
       {
         path: 'delegaciones',
-        element: <AdminSectionPage section="Delegaciones" />,
+        element: <AdminRegionsPage />,
       },
       {
         path: 'usuarios',


### PR DESCRIPTION
## Resumen
- Implementa HU-37: Gestión de Delegaciones (Admin) end-to-end.
- Añade modelo `Region` en Prisma con soft delete (`deletedAt`) e índice `deletedAt`.
- Implementa CRUD backend admin en `/admin/regions` con contrato `ApiResponse<T>`.
- Implementa frontend funcional en `/admin/delegaciones`:
  - buscador
  - botón “Nueva delegación”
  - modal de formulario
  - grid de cards
  - edición y eliminación lógica
  - paginación
- Ajusta el estilo del sidebar admin a tonos verdes de marca.

## Backend
- `Region` en schema + migración:
  - unique en `name`
  - unique en `email`
  - soft delete y orden/consulta de activos
- Nuevo módulo `regions` con:
  - `AdminRegionsController`
  - `RegionsService`
  - DTOs (`create`, `update`, `list query`)

## Frontend
- Nueva feature admin de delegaciones:
  - `types/regions.types.ts`
  - `api/regions.api.ts`
  - `hooks/useRegionsList.ts`
  - `components/regions/*`
  - `pages/AdminRegionsPage/*`
- Ruta `/admin/delegaciones` conectada a `AdminRegionsPage`.

## Validaciones realizadas
- Frontend: `yarn lint` ✅
- Frontend: `yarn build` ✅
- Backend: `yarn prisma:generate` + `yarn build` ✅
- Prueba manual API de create/delete de delegación ✅

## Nota de dependencia
- `booksCount` queda expuesto en contrato y UI, pero actualmente devuelve `0` por dependencia de HU-36 (`HumanBook`/relación con `Region`) aún no implementada/mergeada.
- Queda preparado para conectar el `COUNT` real cuando esté disponible esa relación.
