### PR TITLE
feat(hu-36): gestion de libros humanos (admin)

### DIFF
--- a/backend/prisma/migrations/20260319081749_add_human_book_model/migration.sql
+++ b/backend/prisma/migrations/20260319081749_add_human_book_model/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "HumanBook" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "regionId" INTEGER NOT NULL,
+    "pdfUrl" TEXT NOT NULL,
+    "pdfOriginalName" TEXT NOT NULL,
+    "pdfMimeType" TEXT NOT NULL,
+    "pdfSize" INTEGER NOT NULL,
+    "createdById" INTEGER NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HumanBook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HumanBook_slug_key" ON "HumanBook"("slug");
+
+-- CreateIndex
+CREATE INDEX "HumanBook_deletedAt_idx" ON "HumanBook"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "HumanBook_regionId_idx" ON "HumanBook"("regionId");
+
+-- AddForeignKey
+ALTER TABLE "HumanBook" ADD CONSTRAINT "HumanBook_regionId_fkey" FOREIGN KEY ("regionId") REFERENCES "Region"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HumanBook" ADD CONSTRAINT "HumanBook_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   roles                    Role[]    @relation("UserRoles")
   createdNews              News[]
   createdSuperheroes       Superhero[]
+  createdHumanBooks        HumanBook[]
 }
 
 
@@ -90,5 +91,29 @@ model Region {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  humanBooks HumanBook[]
+
   @@index([deletedAt])
+}
+
+model HumanBook {
+  id              Int       @id @default(autoincrement())
+  name            String
+  title           String
+  slug            String    @unique
+  regionId        Int
+  pdfUrl          String
+  pdfOriginalName String
+  pdfMimeType     String
+  pdfSize         Int
+  createdById     Int
+  deletedAt       DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  region    Region @relation(fields: [regionId], references: [id])
+  createdBy User   @relation(fields: [createdById], references: [id])
+
+  @@index([deletedAt])
+  @@index([regionId])
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { HumanBooksModule } from './human-books/human-books.module';
 import { NewsModule } from './news/news.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { RegionsModule } from './regions/regions.module';
@@ -19,6 +20,7 @@ import { UsersModule } from './users/users.module';
     NewsModule,
     RegionsModule,
     SuperheroesModule,
+    HumanBooksModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/human-books/admin-human-books.controller.ts
+++ b/backend/src/human-books/admin-human-books.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Req,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from '../auth/jwt_strategy/jwt-auth.guard';
+import { Roles } from '../auth/roles/roles.decorator';
+import { RolesGuard } from '../auth/roles/roles.guard';
+import { RoleName } from '../common/types/role-name.enum';
+import { CreateHumanBookDto } from './dto/create-human-book.dto';
+import { UpdateHumanBookDto } from './dto/update-human-book.dto';
+import { type UploadedPdfFile } from './human-book-storage.service';
+import { HumanBooksService } from './human-books.service';
+
+const MAX_PDF_SIZE_BYTES = 10 * 1024 * 1024;
+
+type RequestWithUser = {
+  user: {
+    id: number;
+  };
+};
+
+@Controller('admin/human-books')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(RoleName.ADMIN)
+export class AdminHumanBooksController {
+  constructor(private readonly humanBooksService: HumanBooksService) {}
+
+  @Get()
+  findAll() {
+    return this.humanBooksService.findAllForAdmin();
+  }
+
+  @Post()
+  @UseInterceptors(
+    FileInterceptor('pdf', {
+      limits: { fileSize: MAX_PDF_SIZE_BYTES },
+    }),
+  )
+  create(
+    @Body() createDto: CreateHumanBookDto,
+    @UploadedFile() file: UploadedPdfFile,
+    @Req() request: RequestWithUser,
+  ) {
+    return this.humanBooksService.create(createDto, file, request.user.id);
+  }
+
+  @Patch(':id')
+  @UseInterceptors(
+    FileInterceptor('pdf', {
+      limits: { fileSize: MAX_PDF_SIZE_BYTES },
+    }),
+  )
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateDto: UpdateHumanBookDto,
+    @UploadedFile() file?: UploadedPdfFile,
+  ) {
+    return this.humanBooksService.update(id, updateDto, file);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.humanBooksService.remove(id);
+  }
+}

--- a/backend/src/human-books/dto/create-human-book.dto.ts
+++ b/backend/src/human-books/dto/create-human-book.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class CreateHumanBookDto {
+  @IsString()
+  @IsNotEmpty({ message: 'El nombre es obligatorio' })
+  @MinLength(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+  @MaxLength(150, { message: 'El nombre no puede superar 150 caracteres' })
+  name: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'El título es obligatorio' })
+  @MinLength(2, { message: 'El título debe tener al menos 2 caracteres' })
+  @MaxLength(200, { message: 'El título no puede superar 200 caracteres' })
+  title: string;
+
+  @Type(() => Number)
+  @IsInt({ message: 'La delegación debe ser un ID válido' })
+  @IsNotEmpty({ message: 'La delegación es obligatoria' })
+  regionId: number;
+}

--- a/backend/src/human-books/dto/update-human-book.dto.ts
+++ b/backend/src/human-books/dto/update-human-book.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateHumanBookDto } from './create-human-book.dto';
+
+export class UpdateHumanBookDto extends PartialType(CreateHumanBookDto) {}

--- a/backend/src/human-books/human-book-storage.service.ts
+++ b/backend/src/human-books/human-book-storage.service.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type UploadedPdfFile = {
+  originalname: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+};
+
+const MAX_PDF_SIZE_BYTES = 10 * 1024 * 1024;
+
+@Injectable()
+export class HumanBookStorageService {
+  async savePdf(file: UploadedPdfFile | undefined): Promise<{
+    pdfUrl: string;
+    pdfOriginalName: string;
+    pdfMimeType: string;
+    pdfSize: number;
+  }> {
+    if (!file) {
+      throw new BadRequestException('Debes adjuntar un archivo PDF');
+    }
+
+    this.validatePdf(file);
+
+    const uploadsDir = this.ensureUploadsDirectory();
+    const filename = this.buildPdfFilename(file.originalname);
+    const destinationPath = join(uploadsDir, filename);
+
+    await writeFile(destinationPath, file.buffer);
+
+    return {
+      pdfUrl: `/uploads/human-books/${filename}`,
+      pdfOriginalName: file.originalname,
+      pdfMimeType: file.mimetype,
+      pdfSize: file.size,
+    };
+  }
+
+  async removePdf(pdfUrl: string): Promise<void> {
+    const filename = pdfUrl.replace('/uploads/human-books/', '');
+    const filePath = join(process.cwd(), 'uploads', 'human-books', filename);
+
+    try {
+      await unlink(filePath);
+    } catch {
+      // El archivo puede no existir, no es un error crítico
+    }
+  }
+
+  private validatePdf(file: UploadedPdfFile): void {
+    if (file.mimetype !== 'application/pdf') {
+      throw new BadRequestException('Solo se permiten archivos PDF');
+    }
+
+    if (file.size > MAX_PDF_SIZE_BYTES) {
+      throw new BadRequestException('El PDF no puede superar los 10MB');
+    }
+  }
+
+  private ensureUploadsDirectory(): string {
+    const uploadsDir = join(process.cwd(), 'uploads', 'human-books');
+    if (!existsSync(uploadsDir)) {
+      mkdirSync(uploadsDir, { recursive: true });
+    }
+    return uploadsDir;
+  }
+
+  private buildPdfFilename(originalName: string): string {
+    const baseName = this.normalizeBaseName(originalName);
+    const uniqueFragment = randomUUID().slice(0, 8);
+
+    return `human-book-${Date.now()}-${baseName}-${uniqueFragment}.pdf`;
+  }
+
+  private normalizeBaseName(originalName: string): string {
+    const withoutExtension = originalName.replace(/\.pdf$/i, '');
+
+    const normalized = withoutExtension
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    return normalized || 'libro';
+  }
+}

--- a/backend/src/human-books/human-books.controller.ts
+++ b/backend/src/human-books/human-books.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Param, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { HumanBooksService } from './human-books.service';
+
+@Controller('human-books')
+export class HumanBooksController {
+  constructor(private readonly humanBooksService: HumanBooksService) {}
+
+  @Get()
+  findAllPublished() {
+    return this.humanBooksService.findAllPublished();
+  }
+
+  @Get(':slug/download')
+  async downloadPdf(@Param('slug') slug: string, @Res() res: Response) {
+    const book = await this.humanBooksService.findBySlugForDownload(slug);
+
+    const relativePath = book.pdfUrl.replace(/^\/uploads\//, '');
+    const filePath = join(process.cwd(), 'uploads', relativePath);
+
+    if (!existsSync(filePath)) {
+      return res.status(404).json({
+        success: false,
+        message: 'Archivo PDF no encontrado',
+        data: null,
+      });
+    }
+
+    res.setHeader('Content-Type', book.pdfMimeType);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${book.pdfOriginalName}"`,
+    );
+
+    return res.sendFile(filePath);
+  }
+}

--- a/backend/src/human-books/human-books.module.ts
+++ b/backend/src/human-books/human-books.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AdminHumanBooksController } from './admin-human-books.controller';
+import { HumanBookStorageService } from './human-book-storage.service';
+import { HumanBooksController } from './human-books.controller';
+import { HumanBooksService } from './human-books.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [HumanBooksController, AdminHumanBooksController],
+  providers: [HumanBooksService, HumanBookStorageService],
+})
+export class HumanBooksModule {}

--- a/backend/src/human-books/human-books.service.ts
+++ b/backend/src/human-books/human-books.service.ts
@@ -1,0 +1,217 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { HumanBook, Prisma } from 'generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateHumanBookDto } from './dto/create-human-book.dto';
+import { UpdateHumanBookDto } from './dto/update-human-book.dto';
+import {
+  HumanBookStorageService,
+  type UploadedPdfFile,
+} from './human-book-storage.service';
+
+@Injectable()
+export class HumanBooksService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly storageService: HumanBookStorageService,
+  ) {}
+
+  async findAllForAdmin() {
+    return this.prisma.humanBook.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        region: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  async findAllPublished() {
+    return this.prisma.humanBook.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        region: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  async findBySlugForDownload(slug: string) {
+    const book = await this.prisma.humanBook.findFirst({
+      where: { slug, deletedAt: null },
+    });
+
+    if (!book) {
+      throw new NotFoundException('Libro humano no encontrado');
+    }
+
+    return book;
+  }
+
+  async create(
+    createDto: CreateHumanBookDto,
+    file: UploadedPdfFile | undefined,
+    createdById: number,
+  ) {
+    const pdfData = await this.storageService.savePdf(file);
+    const slug = await this.generateUniqueSlug(createDto.title);
+
+    await this.validateRegionExists(createDto.regionId);
+
+    const humanBook = await this.prisma.humanBook.create({
+      data: {
+        name: createDto.name.trim(),
+        title: createDto.title.trim(),
+        slug,
+        regionId: createDto.regionId,
+        pdfUrl: pdfData.pdfUrl,
+        pdfOriginalName: pdfData.pdfOriginalName,
+        pdfMimeType: pdfData.pdfMimeType,
+        pdfSize: pdfData.pdfSize,
+        createdById,
+      },
+      include: {
+        region: { select: { id: true, name: true } },
+      },
+    });
+
+    return {
+      message: 'Libro humano creado correctamente',
+      humanBook,
+    };
+  }
+
+  async update(
+    id: number,
+    updateDto: UpdateHumanBookDto,
+    file?: UploadedPdfFile,
+  ) {
+    const current = await this.findActiveById(id);
+    const updateData: Prisma.HumanBookUpdateInput = {};
+
+    if (updateDto.name !== undefined) {
+      updateData.name = updateDto.name.trim();
+    }
+
+    if (updateDto.title !== undefined) {
+      updateData.title = updateDto.title.trim();
+      updateData.slug = await this.generateUniqueSlug(updateDto.title, id);
+    }
+
+    if (updateDto.regionId !== undefined) {
+      await this.validateRegionExists(updateDto.regionId);
+      updateData.region = { connect: { id: updateDto.regionId } };
+    }
+
+    if (file) {
+      const pdfData = await this.storageService.savePdf(file);
+      updateData.pdfUrl = pdfData.pdfUrl;
+      updateData.pdfOriginalName = pdfData.pdfOriginalName;
+      updateData.pdfMimeType = pdfData.pdfMimeType;
+      updateData.pdfSize = pdfData.pdfSize;
+
+      await this.storageService.removePdf(current.pdfUrl);
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      throw new BadRequestException(
+        'Debes enviar al menos un campo para actualizar',
+      );
+    }
+
+    const humanBook = await this.prisma.humanBook.update({
+      where: { id },
+      data: updateData,
+      include: {
+        region: { select: { id: true, name: true } },
+      },
+    });
+
+    return {
+      message: 'Libro humano actualizado correctamente',
+      humanBook,
+    };
+  }
+
+  async remove(id: number) {
+    await this.findActiveById(id);
+
+    await this.prisma.humanBook.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    return {
+      message: 'Libro humano eliminado correctamente',
+    };
+  }
+
+  private async findActiveById(id: number): Promise<HumanBook> {
+    const book = await this.prisma.humanBook.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!book) {
+      throw new NotFoundException(`Libro humano con id ${id} no encontrado`);
+    }
+
+    return book;
+  }
+
+  private async validateRegionExists(regionId: number): Promise<void> {
+    const region = await this.prisma.region.findFirst({
+      where: { id: regionId, deletedAt: null },
+    });
+
+    if (!region) {
+      throw new NotFoundException(
+        `Delegación con id ${regionId} no encontrada`,
+      );
+    }
+  }
+
+  private async generateUniqueSlug(title: string, excludedId?: number) {
+    const baseSlug = this.buildBaseSlug(title);
+
+    const where: Prisma.HumanBookWhereInput = {
+      OR: [{ slug: baseSlug }, { slug: { startsWith: `${baseSlug}-` } }],
+    };
+
+    if (excludedId !== undefined) {
+      where.id = { not: excludedId };
+    }
+
+    const existingSlugs = await this.prisma.humanBook.findMany({
+      where,
+      select: { slug: true },
+    });
+
+    const slugSet = new Set(existingSlugs.map((item) => item.slug));
+
+    if (!slugSet.has(baseSlug)) {
+      return baseSlug;
+    }
+
+    let suffix = 2;
+    while (slugSet.has(`${baseSlug}-${suffix}`)) {
+      suffix += 1;
+    }
+
+    return `${baseSlug}-${suffix}`;
+  }
+
+  private buildBaseSlug(title: string): string {
+    const normalized = title
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    return normalized || 'libro-humano';
+  }
+}

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -27,10 +27,7 @@ export class MailService {
     });
   }
 
-  async sendResetPasswordEmail(
-    email: string,
-    token: string,
-  ): Promise<void> {
+  async sendResetPasswordEmail(email: string, token: string): Promise<void> {
     const resetLink = `${this.frontendUrl}/auth/reset-password?token=${token}`;
 
     const mailOptions = {

--- a/backend/src/news/news-image-storage.service.ts
+++ b/backend/src/news/news-image-storage.service.ts
@@ -30,7 +30,9 @@ const ALLOWED_IMAGE_MIME_TYPES = new Set([
 
 @Injectable()
 export class NewsImageStorageService {
-  async saveNewsImage(file: UploadedNewsImageFile | undefined): Promise<string> {
+  async saveNewsImage(
+    file: UploadedNewsImageFile | undefined,
+  ): Promise<string> {
     if (!file) {
       throw new BadRequestException('Debes adjuntar una imagen');
     }

--- a/backend/src/regions/admin-regions.controller.ts
+++ b/backend/src/regions/admin-regions.controller.ts
@@ -30,6 +30,11 @@ export class AdminRegionsController {
     return this.regionsService.findAllForAdmin(query);
   }
 
+  @Get('options')
+  findOptions() {
+    return this.regionsService.findOptions();
+  }
+
   @Post()
   create(@Body() createRegionDto: CreateRegionDto) {
     return this.regionsService.create(createRegionDto);

--- a/backend/src/regions/dto/create-region.dto.ts
+++ b/backend/src/regions/dto/create-region.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateRegionDto {
   @IsString()

--- a/backend/src/regions/regions.service.ts
+++ b/backend/src/regions/regions.service.ts
@@ -18,7 +18,9 @@ type RegionWithBooksCount = Region & {
 export class RegionsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAllForAdmin(query: ListRegionsQueryDto): Promise<RegionWithBooksCount[]> {
+  async findAllForAdmin(
+    query: ListRegionsQueryDto,
+  ): Promise<RegionWithBooksCount[]> {
     const where: Prisma.RegionWhereInput = {
       deletedAt: null,
     };
@@ -46,12 +48,27 @@ export class RegionsService {
       orderBy: {
         name: 'asc',
       },
+      include: {
+        _count: {
+          select: { humanBooks: { where: { deletedAt: null } } },
+        },
+      },
     });
 
     return regions.map((region) => ({
       ...region,
-      booksCount: 0,
+      booksCount: region._count.humanBooks,
     }));
+  }
+
+  async findOptions() {
+    const regions = await this.prisma.region.findMany({
+      where: { deletedAt: null },
+      orderBy: { name: 'asc' },
+      select: { id: true, name: true },
+    });
+
+    return regions;
   }
 
   async create(createRegionDto: CreateRegionDto) {

--- a/backend/src/superheroes/admin-superheroes.controller.ts
+++ b/backend/src/superheroes/admin-superheroes.controller.ts
@@ -67,9 +67,7 @@ const superheroFileFilter = (_req: Request, file, cb) => {
   }
 
   cb(
-    new BadRequestException(
-      'Solo se permiten imágenes PNG, JPEG o WEBP',
-    ),
+    new BadRequestException('Solo se permiten imágenes PNG, JPEG o WEBP'),
     false,
   );
 };

--- a/backend/src/superheroes/dto/list-superheroes-query.dto.ts
+++ b/backend/src/superheroes/dto/list-superheroes-query.dto.ts
@@ -1,13 +1,6 @@
 import { Type } from 'class-transformer';
 import { SuperheroStatus } from 'generated/prisma/client';
-import {
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  Max,
-  Min,
-} from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class ListSuperheroesQueryDto {
   @IsOptional()

--- a/backend/src/superheroes/superheroes.service.ts
+++ b/backend/src/superheroes/superheroes.service.ts
@@ -26,7 +26,9 @@ type SuperheroListData = {
 export class SuperheroesService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAllPublished(query: ListSuperheroesQueryDto): Promise<SuperheroListData> {
+  async findAllPublished(
+    query: ListSuperheroesQueryDto,
+  ): Promise<SuperheroListData> {
     const page = query.page ?? 1;
     const pageSize = query.pageSize ?? 8;
     const skip = (page - 1) * pageSize;
@@ -39,10 +41,7 @@ export class SuperheroesService {
     const [items, total] = await Promise.all([
       this.prisma.superhero.findMany({
         where,
-        orderBy: [
-          { sortOrder: 'asc' },
-          { createdAt: 'desc' },
-        ],
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'desc' }],
         skip,
         take: pageSize,
       }),
@@ -76,7 +75,9 @@ export class SuperheroesService {
     return superhero;
   }
 
-  async findAllForAdmin(query: ListSuperheroesQueryDto): Promise<SuperheroListData> {
+  async findAllForAdmin(
+    query: ListSuperheroesQueryDto,
+  ): Promise<SuperheroListData> {
     const page = query.page ?? 1;
     const pageSize = query.pageSize ?? 10;
     const skip = (page - 1) * pageSize;
@@ -198,8 +199,7 @@ export class SuperheroesService {
       updateData.status = updateSuperheroDto.status;
     }
 
-    const finalImageUrl =
-      imageUrl ?? updateSuperheroDto.imageUrl ?? undefined;
+    const finalImageUrl = imageUrl ?? updateSuperheroDto.imageUrl ?? undefined;
 
     if (finalImageUrl !== undefined) {
       updateData.imageUrl = finalImageUrl;

--- a/frontend/src/features/admin/api/human-books.api.ts
+++ b/frontend/src/features/admin/api/human-books.api.ts
@@ -1,0 +1,93 @@
+import type { AxiosResponse } from 'axios';
+import api from '../../../services/http/axios.instance';
+import type { ApiResponse } from '../../../types/api';
+import { getAuthSession } from '../../auth/utils/auth-session.storage';
+import type {
+  AdminHumanBook,
+  RegionOption,
+} from '../types/human-books.types';
+
+const authHeaders = () => {
+  const token = getAuthSession().accessToken;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const handleResponse = <T>(response: AxiosResponse<ApiResponse<T>>) => response.data;
+
+export const listHumanBooks = async () => {
+  const response = await api.get<ApiResponse<AdminHumanBook[]>>(
+    '/admin/human-books',
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const createHumanBook = async (data: {
+  name: string;
+  title: string;
+  regionId: number;
+  pdf: File;
+}) => {
+  const formData = new FormData();
+  formData.append('name', data.name);
+  formData.append('title', data.title);
+  formData.append('regionId', String(data.regionId));
+  formData.append('pdf', data.pdf);
+
+  const response = await api.post<ApiResponse<{ humanBook: AdminHumanBook }>>(
+    '/admin/human-books',
+    formData,
+    {
+      headers: {
+        ...authHeaders(),
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return handleResponse(response);
+};
+
+export const updateHumanBook = async (data: {
+  id: number;
+  name?: string;
+  title?: string;
+  regionId?: number;
+  pdf?: File;
+}) => {
+  const { id, ...fields } = data;
+  const formData = new FormData();
+
+  if (fields.name !== undefined) formData.append('name', fields.name);
+  if (fields.title !== undefined) formData.append('title', fields.title);
+  if (fields.regionId !== undefined)
+    formData.append('regionId', String(fields.regionId));
+  if (fields.pdf) formData.append('pdf', fields.pdf);
+
+  const response = await api.patch<ApiResponse<{ humanBook: AdminHumanBook }>>(
+    `/admin/human-books/${id}`,
+    formData,
+    {
+      headers: {
+        ...authHeaders(),
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return handleResponse(response);
+};
+
+export const deleteHumanBook = async (id: number) => {
+  const response = await api.delete<ApiResponse<null>>(
+    `/admin/human-books/${id}`,
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const listRegionOptions = async () => {
+  const response = await api.get<ApiResponse<RegionOption[]>>(
+    '/admin/regions/options',
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};

--- a/frontend/src/features/admin/components/human-books/HumanBooksForm/HumanBooksForm.css
+++ b/frontend/src/features/admin/components/human-books/HumanBooksForm/HumanBooksForm.css
@@ -1,0 +1,170 @@
+.human-books-form-card {
+  background: #fff;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(215, 187, 152, 0.6);
+  padding: clamp(1.25rem, 3vw, 1.8rem);
+  box-shadow: 0 20px 40px rgba(15, 52, 110, 0.12);
+}
+
+.human-books-form-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.human-books-form-card__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  color: #6b5d4c;
+  text-transform: uppercase;
+}
+
+.human-books-form-card__header h2 {
+  margin: 0.35rem 0;
+  font-size: clamp(1.6rem, 2.6vw, 2rem);
+  color: var(--brand-dark);
+}
+
+.human-books-form-card__close {
+  border-radius: 999px;
+  border: 1px solid rgba(13, 59, 115, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--brand-secondary);
+  padding: 0.45rem 1rem;
+  font-weight: 600;
+}
+
+.human-books-form-card__feedback {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 225, 181, 0.5);
+  color: #6b5d4c;
+  font-weight: 600;
+}
+
+.human-books-form-card__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.human-books-form-card__grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.human-books-form-card__grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #53443a;
+  font-weight: 600;
+}
+
+.human-books-form-card__grid input,
+.human-books-form-card__grid select {
+  border: 1px solid rgba(207, 207, 207, 0.9);
+  border-radius: 0.8rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+}
+
+.human-books-form-card__grid input:focus,
+.human-books-form-card__grid select:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 2px rgba(107, 170, 117, 0.2);
+}
+
+.human-books-form-card__grid select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='7' viewBox='0 0 12 7'%3E%3Cpath fill='none' stroke='%236b5d4c' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 12px 7px;
+}
+
+.human-books-form-card__grid input[type="file"] {
+  padding: 0.5rem 0.85rem;
+  cursor: pointer;
+}
+
+.human-books-form-card__file-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #6b5d4c;
+  background: rgba(255, 225, 181, 0.3);
+  padding: 0.3rem 0.6rem;
+  border-radius: 0.5rem;
+}
+
+.human-books-form-card__clear-file {
+  border: none;
+  background: none;
+  color: #b91c1c;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  font-size: 1rem;
+}
+
+.human-books-form-card__hint {
+  font-size: 0.75rem;
+  color: #9a8b7a;
+  font-weight: 400;
+}
+
+.human-books-form-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.human-books-form-card__primary {
+  min-width: 180px;
+}
+
+.human-books-form-card__secondary {
+  min-width: 150px;
+}
+
+.human-books-form-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.human-books-form-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 52, 93, 0.45);
+  backdrop-filter: blur(3px);
+}
+
+.human-books-form-modal__content {
+  position: relative;
+  width: min(620px, 90vw);
+  margin: 0 1rem;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .human-books-form-card__actions {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/features/admin/components/human-books/HumanBooksForm/HumanBooksForm.tsx
+++ b/frontend/src/features/admin/components/human-books/HumanBooksForm/HumanBooksForm.tsx
@@ -1,0 +1,149 @@
+import type { ChangeEvent, FormEvent } from 'react';
+import { useRef } from 'react';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import type { RegionOption, HumanBookFormData } from '../../../types/human-books.types';
+import './HumanBooksForm.css';
+
+type HumanBooksFormProps = {
+  isOpen: boolean;
+  formMode: 'create' | 'edit';
+  formData: HumanBookFormData;
+  regions: RegionOption[];
+  feedback?: string | null;
+  isProcessing: boolean;
+  onFieldChange: (field: keyof HumanBookFormData, value: string) => void;
+  onFileChange: (file: File | null) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onReset: () => void;
+  onClose: () => void;
+};
+
+export const HumanBooksForm = ({
+  isOpen,
+  formMode,
+  formData,
+  regions,
+  feedback,
+  isProcessing,
+  onFieldChange,
+  onFileChange,
+  onSubmit,
+  onReset,
+  onClose,
+}: HumanBooksFormProps) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    onFileChange(file);
+  };
+
+  const handleClearFile = () => {
+    onFileChange(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="human-books-form-modal" role="dialog" aria-modal="true">
+      <div className="human-books-form-modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="human-books-form-modal__content">
+        <div className="human-books-form-card">
+          <div className="human-books-form-card__header">
+            <div>
+              <p className="human-books-form-card__eyebrow">Gestión de libros humanos</p>
+              <h2>{formMode === 'create' ? 'Crear libro humano' : 'Editar libro humano'}</h2>
+              <p>Completa los datos y adjunta el PDF para guardar el recurso.</p>
+            </div>
+            <button type="button" className="human-books-form-card__close" onClick={onClose}>
+              Cerrar
+            </button>
+          </div>
+          {feedback && <p className="human-books-form-card__feedback">{feedback}</p>}
+          <form className="human-books-form-card__form" onSubmit={onSubmit}>
+            <div className="human-books-form-card__grid">
+              <label>
+                Nombre
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => onFieldChange('name', e.target.value)}
+                  placeholder="Nombre del recurso"
+                  required
+                />
+              </label>
+              <label>
+                Título
+                <input
+                  type="text"
+                  value={formData.title}
+                  onChange={(e) => onFieldChange('title', e.target.value)}
+                  placeholder="Título del libro humano"
+                  required
+                />
+              </label>
+              <label>
+                Delegación
+                <select
+                  value={formData.regionId}
+                  onChange={(e) => onFieldChange('regionId', e.target.value)}
+                  required
+                >
+                  <option value="">Selecciona una delegación</option>
+                  {regions.map((region) => (
+                    <option key={region.id} value={region.id}>
+                      {region.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Archivo PDF {formMode === 'edit' && '(opcional, reemplaza el actual)'}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/pdf"
+                  onChange={handleFileChange}
+                  required={formMode === 'create'}
+                />
+                {formData.pdf && (
+                  <span className="human-books-form-card__file-info">
+                    {formData.pdf.name}
+                    <button type="button" className="human-books-form-card__clear-file" onClick={handleClearFile}>
+                      <i className="bi bi-x" aria-hidden="true" />
+                    </button>
+                  </span>
+                )}
+                <span className="human-books-form-card__hint">Solo PDF, máximo 10 MB</span>
+              </label>
+            </div>
+            <div className="human-books-form-card__actions">
+              <AdminButton
+                type="submit"
+                variant="solid"
+                className="human-books-form-card__primary"
+                loading={isProcessing}
+                disabled={
+                  !formData.name.trim() ||
+                  !formData.title.trim() ||
+                  !formData.regionId ||
+                  (formMode === 'create' && !formData.pdf)
+                }
+              >
+                {isProcessing ? 'Guardando...' : formMode === 'create' ? 'Crear libro' : 'Guardar cambios'}
+              </AdminButton>
+              <AdminButton variant="outline" className="human-books-form-card__secondary" onClick={onReset} type="button">
+                Limpiar formulario
+              </AdminButton>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/human-books/HumanBooksTable/HumanBooksTable.css
+++ b/frontend/src/features/admin/components/human-books/HumanBooksTable/HumanBooksTable.css
@@ -1,0 +1,60 @@
+.human-books-table {
+  background: var(--brand-white);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(13, 59, 115, 0.1);
+  overflow: hidden;
+  box-shadow: 0 18px 30px rgba(15, 52, 110, 0.08);
+}
+
+.human-books-table__actions {
+  display: inline-flex;
+  gap: 0.45rem;
+}
+
+.human-books-table__actions button {
+  border: none;
+  background: rgba(15, 52, 110, 0.06);
+  color: var(--brand-secondary);
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.8rem;
+  font-weight: 600;
+}
+
+.human-books-table__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  padding: 0;
+  background: rgba(15, 52, 110, 0.06);
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.human-books-table__icon-button i {
+  font-size: 1.1rem;
+}
+
+.human-books-table__icon-button--tool:hover {
+  background: rgba(15, 59, 115, 0.12);
+  color: var(--brand-primary);
+}
+
+.human-books-table__icon-button--delete:hover {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.human-books-table__pdf-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #6b5d4c;
+  font-size: 0.85rem;
+}
+
+.human-books-table__pdf-info i {
+  color: #dc2626;
+  font-size: 1rem;
+}

--- a/frontend/src/features/admin/components/human-books/HumanBooksTable/HumanBooksTable.tsx
+++ b/frontend/src/features/admin/components/human-books/HumanBooksTable/HumanBooksTable.tsx
@@ -1,0 +1,85 @@
+import { AdminDataTable, type AdminTableColumn } from '../../shared/AdminDataTable/AdminDataTable';
+import type { AdminHumanBook } from '../../../types/human-books.types';
+import './HumanBooksTable.css';
+
+type HumanBooksTableProps = {
+  books: AdminHumanBook[];
+  onEdit: (book: AdminHumanBook) => void;
+  onDelete: (book: AdminHumanBook) => void;
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export const HumanBooksTable = ({ books, onEdit, onDelete }: HumanBooksTableProps) => {
+  const columns: AdminTableColumn<AdminHumanBook>[] = [
+    {
+      key: 'name',
+      header: 'Nombre',
+      cell: (book: AdminHumanBook) => book.name,
+    },
+    {
+      key: 'title',
+      header: 'Título',
+      cell: (book: AdminHumanBook) => book.title,
+    },
+    {
+      key: 'region',
+      header: 'Delegación',
+      cell: (book: AdminHumanBook) => book.region.name,
+    },
+    {
+      key: 'pdf',
+      header: 'PDF',
+      cell: (book: AdminHumanBook) => (
+        <span className="human-books-table__pdf-info">
+          <i className="bi bi-file-earmark-pdf" aria-hidden="true" />
+          {formatFileSize(book.pdfSize)}
+        </span>
+      ),
+    },
+    {
+      key: 'updatedAt',
+      header: 'Actualizado',
+      cell: (book: AdminHumanBook) => new Date(book.updatedAt).toLocaleString(),
+    },
+    {
+      key: 'actions',
+      header: 'Acciones',
+      cell: (book: AdminHumanBook) => (
+        <div className="human-books-table__actions">
+          <button
+            type="button"
+            onClick={() => onEdit(book)}
+            aria-label={`Editar ${book.name}`}
+            className="human-books-table__icon-button human-books-table__icon-button--tool"
+          >
+            <i className="bi bi-tools" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(book)}
+            aria-label={`Eliminar ${book.name}`}
+            className="human-books-table__icon-button human-books-table__icon-button--delete"
+          >
+            <i className="bi bi-x-circle" aria-hidden="true" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="human-books-table">
+      <AdminDataTable<AdminHumanBook>
+        columns={columns}
+        rows={books}
+        getRowKey={(book) => book.id.toString()}
+        emptyMessage="No hay libros humanos que coincidan."
+      />
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/human-books/HumanBooksToolbar/HumanBooksToolbar.css
+++ b/frontend/src/features/admin/components/human-books/HumanBooksToolbar/HumanBooksToolbar.css
@@ -1,0 +1,23 @@
+.human-books-toolbar {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-lg);
+  padding: clamp(0.9rem, 1.5vw, 1.3rem) clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid rgba(215, 187, 152, 0.6);
+  box-shadow: 0 14px 28px rgba(32, 26, 17, 0.08);
+}
+
+.human-books-toolbar__new {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.4rem;
+  background: var(--brand-primary);
+  color: var(--brand-white);
+  font-weight: 600;
+  box-shadow: 0 12px 20px rgba(13, 59, 115, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.human-books-toolbar__new:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(13, 59, 115, 0.25);
+}

--- a/frontend/src/features/admin/components/human-books/HumanBooksToolbar/HumanBooksToolbar.tsx
+++ b/frontend/src/features/admin/components/human-books/HumanBooksToolbar/HumanBooksToolbar.tsx
@@ -1,0 +1,33 @@
+import { AdminToolbar } from '../../shared/AdminToolbar/AdminToolbar';
+import { AdminSearchBar } from '../../shared/AdminSearchBar/AdminSearchBar';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import './HumanBooksToolbar.css';
+
+type HumanBooksToolbarProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onNew: () => void;
+};
+
+export const HumanBooksToolbar = ({
+  search,
+  onSearchChange,
+  onNew,
+}: HumanBooksToolbarProps) => (
+  <div className="human-books-toolbar">
+    <AdminToolbar
+      searchSlot={
+        <AdminSearchBar
+          value={search}
+          onChange={onSearchChange}
+          placeholder="Buscar por nombre, título o delegación..."
+        />
+      }
+      actionsSlot={
+        <AdminButton variant="solid" className="human-books-toolbar__new" onClick={onNew}>
+          Nuevo libro humano
+        </AdminButton>
+      }
+    />
+  </div>
+);

--- a/frontend/src/features/admin/hooks/useHumanBooksList.ts
+++ b/frontend/src/features/admin/hooks/useHumanBooksList.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AdminHumanBook } from '../types/human-books.types';
+import { listHumanBooks } from '../api/human-books.api';
+
+type UseHumanBooksListOptions = {
+  onError?: (message: string) => void;
+};
+
+export const useHumanBooksList = ({ onError }: UseHumanBooksListOptions = {}) => {
+  const [books, setBooks] = useState<AdminHumanBook[]>([]);
+  const [search, setSearch] = useState('');
+  const [isFetching, setIsFetching] = useState(false);
+
+  const refreshBooks = useCallback(async () => {
+    setIsFetching(true);
+    try {
+      const response = await listHumanBooks();
+      if (response.success && response.data) {
+        setBooks(response.data);
+      }
+    } catch (error) {
+      console.error('Error al cargar libros humanos', error);
+      onError?.('No se pudo actualizar la lista de libros humanos.');
+    } finally {
+      setIsFetching(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    refreshBooks();
+  }, [refreshBooks]);
+
+  const filteredBooks = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return books;
+
+    return books.filter(
+      (book) =>
+        book.name.toLowerCase().includes(term) ||
+        book.title.toLowerCase().includes(term) ||
+        book.region.name.toLowerCase().includes(term),
+    );
+  }, [books, search]);
+
+  return {
+    filteredBooks,
+    isFetching,
+    refreshBooks,
+    search,
+    setSearch,
+  };
+};

--- a/frontend/src/features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage.css
+++ b/frontend/src/features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage.css
@@ -1,0 +1,38 @@
+.admin-human-books-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.human-books-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #5d6470;
+}
+
+.human-books-pagination__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.human-books-pagination__controls button {
+  border: 1px solid rgba(13, 59, 115, 0.2);
+  background: #fff;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.human-books-pagination__controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.human-books-pagination__controls span {
+  min-width: 80px;
+  text-align: center;
+}

--- a/frontend/src/features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage.tsx
+++ b/frontend/src/features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage.tsx
@@ -1,0 +1,283 @@
+import type { FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { AxiosError } from 'axios';
+import { HumanBooksForm } from '../../components/human-books/HumanBooksForm/HumanBooksForm';
+import { HumanBooksTable } from '../../components/human-books/HumanBooksTable/HumanBooksTable';
+import { HumanBooksToolbar } from '../../components/human-books/HumanBooksToolbar/HumanBooksToolbar';
+import {
+  createHumanBook,
+  deleteHumanBook,
+  listRegionOptions,
+  updateHumanBook,
+} from '../../api/human-books.api';
+import type { AdminHumanBook, HumanBookFormData, RegionOption } from '../../types/human-books.types';
+import { ConfirmModal } from '../../components/shared/ConfirmModal/ConfirmModal';
+import { useHumanBooksList } from '../../hooks/useHumanBooksList';
+import './AdminHumanBooksPage.css';
+
+const initialFormState: HumanBookFormData = {
+  name: '',
+  title: '',
+  regionId: '',
+  pdf: null,
+};
+
+export const AdminHumanBooksPage = () => {
+  const [formData, setFormData] = useState<HumanBookFormData>(initialFormState);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [selectedBook, setSelectedBook] = useState<AdminHumanBook | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [regions, setRegions] = useState<RegionOption[]>([]);
+  const [pendingDelete, setPendingDelete] = useState<AdminHumanBook | null>(null);
+  const formRef = useRef<HTMLDivElement | null>(null);
+  const handleBooksError = useCallback((message: string) => setFeedback(message), []);
+
+  const {
+    filteredBooks,
+    refreshBooks,
+    search,
+    setSearch,
+  } = useHumanBooksList({ onError: handleBooksError });
+
+  const rowsPerPage = 7;
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(filteredBooks.length / rowsPerPage));
+  const paginatedBooks = useMemo(
+    () => filteredBooks.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [filteredBooks, page, rowsPerPage],
+  );
+
+  useEffect(() => {
+    setPage(0);
+  }, [filteredBooks.length, search]);
+
+  useEffect(() => {
+    if (page >= totalPages) {
+      setPage(totalPages - 1);
+    }
+  }, [page, totalPages]);
+
+  useEffect(() => {
+    listRegionOptions()
+      .then((res) => {
+        if (res.success && res.data) {
+          setRegions(res.data);
+        }
+      })
+      .catch(() => {
+        setFeedback('No se pudieron cargar las delegaciones.');
+      });
+  }, []);
+
+  const handleCreateNew = () => {
+    setFormMode('create');
+    setSelectedBook(null);
+    setFormData(initialFormState);
+    setFeedback(null);
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setIsFormOpen(true);
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = formData.name.trim();
+    const trimmedTitle = formData.title.trim();
+    const regionId = Number(formData.regionId);
+
+    if (!trimmedName || !trimmedTitle) {
+      setFeedback('Completa nombre y título.');
+      return;
+    }
+
+    if (!regionId) {
+      setFeedback('Selecciona una delegación.');
+      return;
+    }
+
+    if (formMode === 'create' && !formData.pdf) {
+      setFeedback('Adjunta un archivo PDF.');
+      return;
+    }
+
+    if (formMode === 'edit' && !selectedBook) {
+      setFeedback('Selecciona un libro antes de editar.');
+      return;
+    }
+
+    setIsProcessing(true);
+    setFeedback(null);
+
+    try {
+      const response =
+        formMode === 'create'
+          ? await createHumanBook({
+              name: trimmedName,
+              title: trimmedTitle,
+              regionId,
+              pdf: formData.pdf!,
+            })
+          : await updateHumanBook({
+              id: selectedBook!.id,
+              name: trimmedName,
+              title: trimmedTitle,
+              regionId,
+              ...(formData.pdf ? { pdf: formData.pdf } : {}),
+            });
+
+      if (response.success) {
+        setFeedback(formMode === 'create' ? 'Libro humano creado con éxito.' : 'Libro humano actualizado.');
+        setFormData(initialFormState);
+        setFormMode('create');
+        setSelectedBook(null);
+        setIsFormOpen(false);
+        await refreshBooks();
+      } else {
+        setFeedback(response.message || 'No se pudo guardar el libro humano.');
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      const serverMessage = axiosError.response?.data?.message;
+      setFeedback(serverMessage || 'Error al intentar guardar el libro humano.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleEdit = (book: AdminHumanBook) => {
+    setFormMode('edit');
+    setSelectedBook(book);
+    setFormData({
+      name: book.name,
+      title: book.title,
+      regionId: String(book.regionId),
+      pdf: null,
+    });
+    setFeedback(null);
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = (book: AdminHumanBook) => {
+    setPendingDelete(book);
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+
+    setIsProcessing(true);
+    setFeedback(null);
+    try {
+      const response = await deleteHumanBook(pendingDelete.id);
+      if (response.success) {
+        setFeedback('Libro humano eliminado.');
+        await refreshBooks();
+      } else {
+        setFeedback(response.message || 'No se pudo eliminar el libro humano.');
+      }
+    } catch (error) {
+      console.error('Error al eliminar libro humano', error);
+      setFeedback('No se pudo eliminar el libro humano.');
+    } finally {
+      setIsProcessing(false);
+      setPendingDelete(null);
+    }
+  };
+
+  const handleFieldChange = (field: keyof HumanBookFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFeedback(null);
+  };
+
+  const handleFileChange = (file: File | null) => {
+    setFormData((prev) => ({ ...prev, pdf: file }));
+    setFeedback(null);
+  };
+
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    setFormMode('create');
+    setSelectedBook(null);
+    setFormData(initialFormState);
+    setFeedback(null);
+  };
+
+  return (
+    <section className="admin-human-books-page">
+      <div ref={formRef}>
+        <HumanBooksForm
+          isOpen={isFormOpen}
+          formMode={formMode}
+          formData={formData}
+          regions={regions}
+          feedback={feedback}
+          isProcessing={isProcessing}
+          onFieldChange={handleFieldChange}
+          onFileChange={handleFileChange}
+          onSubmit={handleFormSubmit}
+          onReset={handleCreateNew}
+          onClose={handleCloseForm}
+        />
+      </div>
+
+      <HumanBooksToolbar
+        search={search}
+        onSearchChange={setSearch}
+        onNew={handleCreateNew}
+      />
+
+      <HumanBooksTable
+        books={paginatedBooks}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
+
+      <div className="human-books-pagination">
+        <div className="human-books-pagination__info">
+          Mostrando {filteredBooks.length === 0 ? 0 : page * rowsPerPage + 1}-
+          {Math.min(filteredBooks.length, (page + 1) * rowsPerPage)} de {filteredBooks.length}
+        </div>
+        <div className="human-books-pagination__controls">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(0, prev - 1))}
+            disabled={page === 0}
+            aria-label="Página anterior"
+          >
+            ←
+          </button>
+          <span>
+            {page + 1} de {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.min(totalPages - 1, prev + 1))}
+            disabled={page >= totalPages - 1}
+            aria-label="Página siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+
+      <ConfirmModal
+        isOpen={Boolean(pendingDelete)}
+        title="Eliminar libro humano"
+        description={
+          pendingDelete ? (
+            <>
+              ¿Quieres eliminar el libro{' '}
+              <strong>{pendingDelete.name}</strong>? Esta acción marcará el recurso como eliminado.
+            </>
+          ) : undefined
+        }
+        confirmLabel="Sí, eliminar"
+        cancelLabel="Cancelar"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+        isProcessing={isProcessing}
+      />
+    </section>
+  );
+};

--- a/frontend/src/features/admin/types/human-books.types.ts
+++ b/frontend/src/features/admin/types/human-books.types.ts
@@ -1,0 +1,46 @@
+export type AdminHumanBook = {
+  id: number;
+  name: string;
+  title: string;
+  slug: string;
+  regionId: number;
+  pdfUrl: string;
+  pdfOriginalName: string;
+  pdfMimeType: string;
+  pdfSize: number;
+  createdById: number;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  region: {
+    id: number;
+    name: string;
+  };
+};
+
+export type RegionOption = {
+  id: number;
+  name: string;
+};
+
+export type CreateHumanBookPayload = {
+  name: string;
+  title: string;
+  regionId: number;
+  pdf: File;
+};
+
+export type UpdateHumanBookPayload = {
+  id: number;
+  name?: string;
+  title?: string;
+  regionId?: number;
+  pdf?: File;
+};
+
+export type HumanBookFormData = {
+  name: string;
+  title: string;
+  regionId: string;
+  pdf: File | null;
+};

--- a/frontend/src/router/app.router.tsx
+++ b/frontend/src/router/app.router.tsx
@@ -4,6 +4,7 @@ import { AuthPage } from '../features/auth/pages/AuthPage/AuthPage';
 import { ResetPasswordPage } from '../features/auth/pages/ResetPasswordPage/ResetPasswordPage';
 import { AdminLayout } from '../features/admin/components/layout/AdminLayout/AdminLayout';
 import { AdminDashboardPage } from '../features/admin/pages/AdminDashboardPage/AdminDashboardPage';
+import { AdminHumanBooksPage } from '../features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage';
 import { AdminNewsPage } from '../features/admin/pages/AdminNewsPage/AdminNewsPage';
 import { AdminRegionsPage } from '../features/admin/pages/AdminRegionsPage/AdminRegionsPage';
 import { AdminUsersPage } from '../features/admin/pages/AdminUsersPage/AdminUsersPage';
@@ -76,7 +77,7 @@ export const appRouter = createBrowserRouter([
       },
       {
         path: 'libros',
-        element: <AdminSectionPage section="Libros Humanos" />,
+        element: <AdminHumanBooksPage />,
       },
       {
         path: 'heroes',


### PR DESCRIPTION
## Descripción

Implementación completa del módulo de **Libros Humanos** en el panel de administración, incluyendo backend y frontend.

## Backend

- Modelo `HumanBook` con migración Prisma (relación con `Region` y `User`)
- CRUD completo con borrado lógico (soft-delete)
- Subida y almacenamiento de archivos PDF en `uploads/human-books/`
- Endpoint `/admin/regions/options` para alimentar el selector de delegaciones
- Controlador público con listado y descarga de PDF por slug

## Frontend

- Página de administración con listado en tabla, búsqueda y paginación
- Modal con formulario de alta y edición (nombre, título, delegación, PDF)
- Confirmación de borrado con modal
- Integración con la API mediante hooks y servicios tipados

## Notas

- Los PDFs permanecen en disco tras el soft-delete (pendiente de decisión, ver TODO en README)
- Se requiere al menos una delegación creada para poder crear un libro humano