### PR TITLE
Feature/hu 38 gestion de retos admin

### DIFF
--- a/backend/prisma/migrations/20260319164132_add_challenges_model/migration.sql
+++ b/backend/prisma/migrations/20260319164132_add_challenges_model/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Challenge" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "targetAmount" INTEGER NOT NULL,
+    "currentAmount" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Challenge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Challenge_deletedAt_idx" ON "Challenge"("deletedAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -117,3 +117,17 @@ model HumanBook {
   @@index([deletedAt])
   @@index([regionId])
 }
+
+model Challenge {
+  id            Int       @id @default(autoincrement())
+  title         String
+  description   String    @db.Text
+  targetAmount  Int
+  currentAmount Int       @default(0)
+  isActive      Boolean   @default(true)
+  deletedAt     DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([deletedAt])
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { ChallengesModule } from './challenges/challenges.module';
 import { HumanBooksModule } from './human-books/human-books.module';
 import { NewsModule } from './news/news.module';
 import { PrismaModule } from './prisma/prisma.module';
@@ -21,6 +22,7 @@ import { UsersModule } from './users/users.module';
     RegionsModule,
     SuperheroesModule,
     HumanBooksModule,
+    ChallengesModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/challenges/admin-challenges.controller.ts
+++ b/backend/src/challenges/admin-challenges.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt_strategy/jwt-auth.guard';
+import { Roles } from '../auth/roles/roles.decorator';
+import { RolesGuard } from '../auth/roles/roles.guard';
+import { RoleName } from '../common/types/role-name.enum';
+import { ChallengesService } from './challenges.service';
+import { CreateChallengeDto } from './dto/create-challenge.dto';
+import { UpdateChallengeDto } from './dto/update-challenge.dto';
+import { UpdateChallengeAmountDto } from './dto/update-challenge-amount.dto';
+
+@Controller('admin/challenges')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(RoleName.ADMIN)
+export class AdminChallengesController {
+  constructor(private readonly challengesService: ChallengesService) {}
+
+  @Get()
+  findAll() {
+    return this.challengesService.findAllForAdmin();
+  }
+
+  @Post()
+  create(@Body() createChallengeDto: CreateChallengeDto) {
+    return this.challengesService.create(createChallengeDto);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateChallengeDto: UpdateChallengeDto,
+  ) {
+    return this.challengesService.update(id, updateChallengeDto);
+  }
+
+  @Patch(':id/amount')
+  updateAmount(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateAmountDto: UpdateChallengeAmountDto,
+  ) {
+    return this.challengesService.updateAmount(id, updateAmountDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.challengesService.remove(id);
+  }
+}

--- a/backend/src/challenges/challenges.module.ts
+++ b/backend/src/challenges/challenges.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AdminChallengesController } from './admin-challenges.controller';
+import { ChallengesService } from './challenges.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [AdminChallengesController],
+  providers: [ChallengesService],
+})
+export class ChallengesModule {}

--- a/backend/src/challenges/challenges.service.ts
+++ b/backend/src/challenges/challenges.service.ts
@@ -1,0 +1,143 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { Challenge, Prisma } from 'generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateChallengeDto } from './dto/create-challenge.dto';
+import { UpdateChallengeDto } from './dto/update-challenge.dto';
+import { UpdateChallengeAmountDto } from './dto/update-challenge-amount.dto';
+
+@Injectable()
+export class ChallengesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAllForAdmin(): Promise<Challenge[]> {
+    return this.prisma.challenge.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async create(dto: CreateChallengeDto) {
+    if (
+      dto.currentAmount !== undefined &&
+      dto.currentAmount > dto.targetAmount
+    ) {
+      throw new BadRequestException(
+        'El monto actual no puede superar el monto objetivo',
+      );
+    }
+
+    const challenge = await this.prisma.challenge.create({
+      data: {
+        title: dto.title,
+        description: dto.description,
+        targetAmount: dto.targetAmount,
+        currentAmount: dto.currentAmount ?? 0,
+        isActive: dto.isActive ?? true,
+      },
+    });
+
+    return {
+      message: 'Reto creado correctamente',
+      challenge,
+    };
+  }
+
+  async update(id: number, dto: UpdateChallengeDto) {
+    const current = await this.findActiveById(id);
+    const updateData: Prisma.ChallengeUpdateInput = {};
+
+    if (dto.title !== undefined) {
+      updateData.title = dto.title;
+    }
+
+    if (dto.description !== undefined) {
+      updateData.description = dto.description;
+    }
+
+    if (dto.isActive !== undefined) {
+      updateData.isActive = dto.isActive;
+    }
+
+    const nextTarget = dto.targetAmount ?? current.targetAmount;
+    const nextCurrent = dto.currentAmount ?? current.currentAmount;
+
+    if (nextCurrent > nextTarget) {
+      throw new BadRequestException(
+        'El monto actual no puede superar el monto objetivo',
+      );
+    }
+
+    if (dto.targetAmount !== undefined) {
+      updateData.targetAmount = dto.targetAmount;
+    }
+
+    if (dto.currentAmount !== undefined) {
+      updateData.currentAmount = dto.currentAmount;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      throw new BadRequestException(
+        'Debes enviar al menos un campo para actualizar',
+      );
+    }
+
+    const challenge = await this.prisma.challenge.update({
+      where: { id },
+      data: updateData,
+    });
+
+    return {
+      message: 'Reto actualizado correctamente',
+      challenge,
+    };
+  }
+
+  async updateAmount(id: number, dto: UpdateChallengeAmountDto) {
+    const current = await this.findActiveById(id);
+
+    if (dto.currentAmount > current.targetAmount) {
+      throw new BadRequestException(
+        'El monto actual no puede superar el monto objetivo',
+      );
+    }
+
+    const challenge = await this.prisma.challenge.update({
+      where: { id },
+      data: { currentAmount: dto.currentAmount },
+    });
+
+    return {
+      message: 'Monto actualizado correctamente',
+      challenge,
+    };
+  }
+
+  async remove(id: number) {
+    await this.findActiveById(id);
+
+    await this.prisma.challenge.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    return {
+      message: 'Reto eliminado correctamente',
+    };
+  }
+
+  private async findActiveById(id: number): Promise<Challenge> {
+    const challenge = await this.prisma.challenge.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!challenge) {
+      throw new NotFoundException(`Reto con id ${id} no encontrado`);
+    }
+
+    return challenge;
+  }
+}

--- a/backend/src/challenges/dto/create-challenge.dto.ts
+++ b/backend/src/challenges/dto/create-challenge.dto.ts
@@ -1,0 +1,34 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class CreateChallengeDto {
+  @IsString()
+  @IsNotEmpty({ message: 'El título es obligatorio' })
+  title: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'La descripción es obligatoria' })
+  description: string;
+
+  @Type(() => Number)
+  @IsInt({ message: 'El monto objetivo debe ser un número entero' })
+  @Min(1, { message: 'El monto objetivo debe ser mayor que 0' })
+  targetAmount: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'El monto actual debe ser un número entero' })
+  @Min(0, { message: 'El monto actual no puede ser negativo' })
+  currentAmount?: number;
+
+  @IsOptional()
+  @IsBoolean({ message: 'El estado activo debe ser un valor booleano' })
+  isActive?: boolean;
+}

--- a/backend/src/challenges/dto/update-challenge-amount.dto.ts
+++ b/backend/src/challenges/dto/update-challenge-amount.dto.ts
@@ -1,0 +1,9 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class UpdateChallengeAmountDto {
+  @Type(() => Number)
+  @IsInt({ message: 'El monto debe ser un número entero' })
+  @Min(0, { message: 'El monto no puede ser negativo' })
+  currentAmount: number;
+}

--- a/backend/src/challenges/dto/update-challenge.dto.ts
+++ b/backend/src/challenges/dto/update-challenge.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateChallengeDto } from './create-challenge.dto';
+
+export class UpdateChallengeDto extends PartialType(CreateChallengeDto) {}

--- a/backend/uploads/human-books/.gitignore
+++ b/backend/uploads/human-books/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/frontend/src/features/admin/api/challenges.api.ts
+++ b/frontend/src/features/admin/api/challenges.api.ts
@@ -1,0 +1,64 @@
+import type { AxiosResponse } from 'axios';
+import { getAuthSession } from '../../auth/utils/auth-session.storage';
+import api from '../../../services/http/axios.instance';
+import type { ApiResponse } from '../../../types/api';
+import type {
+  AdminChallenge,
+  CreateChallengePayload,
+  UpdateChallengePayload,
+  UpdateChallengeAmountPayload,
+} from '../types/challenges.types';
+
+const authHeaders = () => {
+  const token = getAuthSession().accessToken;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const handleResponse = <T>(response: AxiosResponse<ApiResponse<T>>) =>
+  response.data;
+
+export const listAdminChallenges = async () => {
+  const response = await api.get<ApiResponse<AdminChallenge[]>>(
+    '/admin/challenges',
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const createAdminChallenge = async (payload: CreateChallengePayload) => {
+  const response = await api.post<ApiResponse<AdminChallenge>>(
+    '/admin/challenges',
+    payload,
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const updateAdminChallenge = async (payload: UpdateChallengePayload) => {
+  const { id, ...body } = payload;
+  const response = await api.patch<ApiResponse<AdminChallenge>>(
+    `/admin/challenges/${id}`,
+    body,
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const updateAdminChallengeAmount = async (
+  payload: UpdateChallengeAmountPayload,
+) => {
+  const response = await api.patch<ApiResponse<AdminChallenge>>(
+    `/admin/challenges/${payload.id}/amount`,
+    { currentAmount: payload.currentAmount },
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};
+
+export const deleteAdminChallenge = async (id: number) => {
+  const response = await api.delete<ApiResponse<null>>(
+    `/admin/challenges/${id}`,
+    { headers: authHeaders() },
+  );
+  return handleResponse(response);
+};

--- a/frontend/src/features/admin/components/challenges/ChallengeCard/ChallengeCard.css
+++ b/frontend/src/features/admin/components/challenges/ChallengeCard/ChallengeCard.css
@@ -1,0 +1,109 @@
+.challenge-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.challenge-card:hover {
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.12);
+}
+
+.challenge-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.challenge-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1e293b;
+  line-height: 1.3;
+}
+
+.challenge-card__status {
+  flex-shrink: 0;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.challenge-card__status--active {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.challenge-card__status--inactive {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.challenge-card__amounts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.challenge-card__amount-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.challenge-card__amount-label {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.challenge-card__amount-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.challenge-card__progress {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.challenge-card__progress-bar {
+  flex: 1;
+  height: 0.5rem;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.challenge-card__progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #14b8a6, #0ea5e9);
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+.challenge-card__progress-text {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #475569;
+  min-width: 3rem;
+  text-align: right;
+}
+
+.challenge-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f1f5f9;
+}

--- a/frontend/src/features/admin/components/challenges/ChallengeCard/ChallengeCard.tsx
+++ b/frontend/src/features/admin/components/challenges/ChallengeCard/ChallengeCard.tsx
@@ -1,0 +1,81 @@
+import type { AdminChallenge } from '../../../types/challenges.types';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import './ChallengeCard.css';
+
+type ChallengeCardProps = {
+  challenge: AdminChallenge;
+  onEdit: (challenge: AdminChallenge) => void;
+  onUpdateAmount: (challenge: AdminChallenge) => void;
+  onDelete: (challenge: AdminChallenge) => void;
+};
+
+export const ChallengeCard = ({
+  challenge,
+  onEdit,
+  onUpdateAmount,
+  onDelete,
+}: ChallengeCardProps) => {
+  const progress = challenge.targetAmount > 0
+    ? Math.min((challenge.currentAmount / challenge.targetAmount) * 100, 100)
+    : 0;
+
+  const formatAmount = (cents: number) => {
+    const euros = cents / 100;
+    return euros.toLocaleString('es-ES', {
+      style: 'currency',
+      currency: 'EUR',
+    });
+  };
+
+  return (
+    <article className="challenge-card">
+      <div className="challenge-card__header">
+        <h3 className="challenge-card__title">{challenge.title}</h3>
+        <span
+          className={`challenge-card__status challenge-card__status--${challenge.isActive ? 'active' : 'inactive'}`}
+        >
+          {challenge.isActive ? 'Activo' : 'Inactivo'}
+        </span>
+      </div>
+
+      <div className="challenge-card__amounts">
+        <div className="challenge-card__amount-row">
+          <span className="challenge-card__amount-label">Recaudado</span>
+          <span className="challenge-card__amount-value">
+            {formatAmount(challenge.currentAmount)}
+          </span>
+        </div>
+        <div className="challenge-card__amount-row">
+          <span className="challenge-card__amount-label">Objetivo</span>
+          <span className="challenge-card__amount-value">
+            {formatAmount(challenge.targetAmount)}
+          </span>
+        </div>
+      </div>
+
+      <div className="challenge-card__progress">
+        <div className="challenge-card__progress-bar">
+          <div
+            className="challenge-card__progress-fill"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <span className="challenge-card__progress-text">
+          {progress.toFixed(0)}%
+        </span>
+      </div>
+
+      <div className="challenge-card__actions">
+        <AdminButton variant="outline" onClick={() => onEdit(challenge)}>
+          Editar
+        </AdminButton>
+        <AdminButton variant="outline" onClick={() => onUpdateAmount(challenge)}>
+          Actualizar monto
+        </AdminButton>
+        <AdminButton variant="ghost" onClick={() => onDelete(challenge)}>
+          Eliminar
+        </AdminButton>
+      </div>
+    </article>
+  );
+};

--- a/frontend/src/features/admin/components/challenges/ChallengeForm/ChallengeForm.css
+++ b/frontend/src/features/admin/components/challenges/ChallengeForm/ChallengeForm.css
@@ -1,0 +1,125 @@
+.challenge-form-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.challenge-form-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.challenge-form-modal__content {
+  position: relative;
+  width: 100%;
+  max-width: 540px;
+  max-height: 90vh;
+  overflow-y: auto;
+  margin: 1rem;
+}
+
+.challenge-form-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.25);
+}
+
+.challenge-form-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.challenge-form-card__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.challenge-form-card__close {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: #94a3b8;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  transition: color 0.15s ease;
+}
+
+.challenge-form-card__close:hover {
+  color: #475569;
+}
+
+.challenge-form-card__feedback {
+  margin: 0 0 1rem;
+  padding: 0.6rem 1rem;
+  border-radius: 0.5rem;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.challenge-form-card__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.challenge-form-card__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.challenge-form-card__field input[type='text'],
+.challenge-form-card__field input[type='number'],
+.challenge-form-card__field textarea {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: #1e293b;
+  transition: border-color 0.15s ease;
+}
+
+.challenge-form-card__field input:focus,
+.challenge-form-card__field textarea:focus {
+  outline: none;
+  border-color: #0ea5e9;
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.15);
+}
+
+.challenge-form-card__field--toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.challenge-form-card__field--toggle input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #0ea5e9;
+}
+
+.challenge-form-card__field--full {
+  grid-column: 1 / -1;
+}
+
+.challenge-form-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}

--- a/frontend/src/features/admin/components/challenges/ChallengeForm/ChallengeForm.tsx
+++ b/frontend/src/features/admin/components/challenges/ChallengeForm/ChallengeForm.tsx
@@ -1,0 +1,141 @@
+import type { FormEvent } from 'react';
+import type { ChallengeFormData } from '../../../types/challenges.types';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import './ChallengeForm.css';
+
+type ChallengeFormProps = {
+  isOpen: boolean;
+  formMode: 'create' | 'edit';
+  formData: ChallengeFormData;
+  isProcessing: boolean;
+  feedback: string | null;
+  onFieldChange: (field: keyof ChallengeFormData, value: string | boolean) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onClose: () => void;
+};
+
+export const ChallengeForm = ({
+  isOpen,
+  formMode,
+  formData,
+  isProcessing,
+  feedback,
+  onFieldChange,
+  onSubmit,
+  onClose,
+}: ChallengeFormProps) => {
+  if (!isOpen) return null;
+
+  const isSaveDisabled =
+    !formData.title.trim() ||
+    !formData.description.trim() ||
+    !formData.targetAmount.trim() ||
+    isProcessing;
+
+  return (
+    <div className="challenge-form-modal" role="dialog" aria-modal="true">
+      <div
+        className="challenge-form-modal__backdrop"
+        onClick={onClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+        }}
+        role="presentation"
+      />
+
+      <div className="challenge-form-modal__content">
+        <div className="challenge-form-card">
+          <div className="challenge-form-card__header">
+            <h2>{formMode === 'create' ? 'Nuevo reto' : 'Editar reto'}</h2>
+            <button
+              type="button"
+              className="challenge-form-card__close"
+              onClick={onClose}
+              aria-label="Cerrar"
+            >
+              ✕
+            </button>
+          </div>
+
+          {feedback && (
+            <p className="challenge-form-card__feedback" role="status">
+              {feedback}
+            </p>
+          )}
+
+          <form onSubmit={onSubmit}>
+            <div className="challenge-form-card__grid">
+              <label className="challenge-form-card__field">
+                Título *
+                <input
+                  type="text"
+                  value={formData.title}
+                  onChange={(e) => onFieldChange('title', e.target.value)}
+                  required
+                />
+              </label>
+
+              <label className="challenge-form-card__field">
+                Monto objetivo (céntimos) *
+                <input
+                  type="number"
+                  min={1}
+                  value={formData.targetAmount}
+                  onChange={(e) => onFieldChange('targetAmount', e.target.value)}
+                  required
+                />
+              </label>
+
+              <label className="challenge-form-card__field">
+                Monto actual (céntimos)
+                <input
+                  type="number"
+                  min={0}
+                  value={formData.currentAmount}
+                  onChange={(e) =>
+                    onFieldChange('currentAmount', e.target.value)
+                  }
+                />
+              </label>
+
+              <label className="challenge-form-card__field challenge-form-card__field--toggle">
+                <span>Activo</span>
+                <input
+                  type="checkbox"
+                  checked={formData.isActive}
+                  onChange={(e) => onFieldChange('isActive', e.target.checked)}
+                />
+              </label>
+
+              <label className="challenge-form-card__field challenge-form-card__field--full">
+                Descripción *
+                <textarea
+                  rows={4}
+                  value={formData.description}
+                  onChange={(e) =>
+                    onFieldChange('description', e.target.value)
+                  }
+                  required
+                />
+              </label>
+            </div>
+
+            <div className="challenge-form-card__actions">
+              <AdminButton
+                type="submit"
+                variant="solid"
+                disabled={isSaveDisabled}
+                loading={isProcessing}
+              >
+                {formMode === 'create' ? 'Crear' : 'Guardar'}
+              </AdminButton>
+              <AdminButton variant="outline" type="button" onClick={onClose}>
+                Cancelar
+              </AdminButton>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/challenges/ChallengesGrid/ChallengesGrid.css
+++ b/frontend/src/features/admin/components/challenges/ChallengesGrid/ChallengesGrid.css
@@ -1,0 +1,12 @@
+.challenges-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.challenges-grid__empty {
+  text-align: center;
+  color: #94a3b8;
+  padding: 3rem 1rem;
+  font-size: 0.95rem;
+}

--- a/frontend/src/features/admin/components/challenges/ChallengesGrid/ChallengesGrid.tsx
+++ b/frontend/src/features/admin/components/challenges/ChallengesGrid/ChallengesGrid.tsx
@@ -1,0 +1,37 @@
+import type { AdminChallenge } from '../../../types/challenges.types';
+import { ChallengeCard } from '../ChallengeCard/ChallengeCard';
+import './ChallengesGrid.css';
+
+type ChallengesGridProps = {
+  challenges: AdminChallenge[];
+  onEdit: (challenge: AdminChallenge) => void;
+  onUpdateAmount: (challenge: AdminChallenge) => void;
+  onDelete: (challenge: AdminChallenge) => void;
+};
+
+export const ChallengesGrid = ({
+  challenges,
+  onEdit,
+  onUpdateAmount,
+  onDelete,
+}: ChallengesGridProps) => {
+  if (challenges.length === 0) {
+    return (
+      <p className="challenges-grid__empty">No se encontraron retos.</p>
+    );
+  }
+
+  return (
+    <div className="challenges-grid">
+      {challenges.map((challenge) => (
+        <ChallengeCard
+          key={challenge.id}
+          challenge={challenge}
+          onEdit={onEdit}
+          onUpdateAmount={onUpdateAmount}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/features/admin/components/challenges/ChallengesToolbar/ChallengesToolbar.tsx
+++ b/frontend/src/features/admin/components/challenges/ChallengesToolbar/ChallengesToolbar.tsx
@@ -1,0 +1,30 @@
+import { AdminToolbar } from '../../shared/AdminToolbar/AdminToolbar';
+import { AdminSearchBar } from '../../shared/AdminSearchBar/AdminSearchBar';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+
+type ChallengesToolbarProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onNew: () => void;
+};
+
+export const ChallengesToolbar = ({
+  search,
+  onSearchChange,
+  onNew,
+}: ChallengesToolbarProps) => (
+  <AdminToolbar
+    searchSlot={
+      <AdminSearchBar
+        value={search}
+        onChange={onSearchChange}
+        placeholder="Buscar por título..."
+      />
+    }
+    actionsSlot={
+      <AdminButton variant="solid" onClick={onNew}>
+        Nuevo reto
+      </AdminButton>
+    }
+  />
+);

--- a/frontend/src/features/admin/components/challenges/UpdateAmountModal/UpdateAmountModal.css
+++ b/frontend/src/features/admin/components/challenges/UpdateAmountModal/UpdateAmountModal.css
@@ -1,0 +1,79 @@
+.update-amount-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.update-amount-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.update-amount-modal__content {
+  position: relative;
+  background: #fff;
+  border-radius: 1rem;
+  padding: 2rem;
+  width: 100%;
+  max-width: 420px;
+  margin: 1rem;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.25);
+}
+
+.update-amount-modal__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.update-amount-modal__info {
+  font-size: 0.88rem;
+  color: #64748b;
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.update-amount-modal__error {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: #fee2e2;
+  color: #991b1b;
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.update-amount-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+  margin-bottom: 1.25rem;
+}
+
+.update-amount-modal__field input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  color: #1e293b;
+  transition: border-color 0.15s ease;
+}
+
+.update-amount-modal__field input:focus {
+  outline: none;
+  border-color: #0ea5e9;
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.15);
+}
+
+.update-amount-modal__actions {
+  display: flex;
+  gap: 0.75rem;
+}

--- a/frontend/src/features/admin/components/challenges/UpdateAmountModal/UpdateAmountModal.tsx
+++ b/frontend/src/features/admin/components/challenges/UpdateAmountModal/UpdateAmountModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import type { AdminChallenge } from '../../../types/challenges.types';
+import { AdminButton } from '../../shared/AdminButton/AdminButton';
+import './UpdateAmountModal.css';
+
+type UpdateAmountModalProps = {
+  isOpen: boolean;
+  challenge: AdminChallenge | null;
+  isProcessing: boolean;
+  onConfirm: (currentAmount: number) => void;
+  onCancel: () => void;
+};
+
+export const UpdateAmountModal = ({
+  isOpen,
+  challenge,
+  isProcessing,
+  onConfirm,
+  onCancel,
+}: UpdateAmountModalProps) => {
+  const [amount, setAmount] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen || !challenge) return null;
+
+  const handleConfirm = () => {
+    const parsed = Number(amount);
+
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      setError('El monto debe ser un número entero no negativo.');
+      return;
+    }
+
+    if (parsed > challenge.targetAmount) {
+      setError('El monto no puede superar el objetivo.');
+      return;
+    }
+
+    setError(null);
+    onConfirm(parsed);
+  };
+
+  const handleClose = () => {
+    setAmount('');
+    setError(null);
+    onCancel();
+  };
+
+  const formatAmount = (cents: number) => {
+    const euros = cents / 100;
+    return euros.toLocaleString('es-ES', {
+      style: 'currency',
+      currency: 'EUR',
+    });
+  };
+
+  return (
+    <div className="update-amount-modal" role="dialog" aria-modal="true">
+      <div
+        className="update-amount-modal__backdrop"
+        onClick={handleClose}
+        role="presentation"
+      />
+
+      <div className="update-amount-modal__content">
+        <h3 className="update-amount-modal__title">Actualizar monto</h3>
+        <p className="update-amount-modal__info">
+          Reto: <strong>{challenge.title}</strong>
+          <br />
+          Objetivo: {formatAmount(challenge.targetAmount)}
+        </p>
+
+        {error && (
+          <p className="update-amount-modal__error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <label className="update-amount-modal__field">
+          Nuevo monto actual (céntimos)
+          <input
+            type="number"
+            min={0}
+            max={challenge.targetAmount}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            autoFocus
+          />
+        </label>
+
+        <div className="update-amount-modal__actions">
+          <AdminButton
+            variant="solid"
+            onClick={handleConfirm}
+            loading={isProcessing}
+            disabled={!amount.trim() || isProcessing}
+          >
+            Actualizar
+          </AdminButton>
+          <AdminButton variant="outline" onClick={handleClose} disabled={isProcessing}>
+            Cancelar
+          </AdminButton>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/admin/hooks/useAdminChallengesList.ts
+++ b/frontend/src/features/admin/hooks/useAdminChallengesList.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { listAdminChallenges } from '../api/challenges.api';
+import type { AdminChallenge } from '../types/challenges.types';
+
+type UseAdminChallengesListOptions = {
+  onError?: (message: string) => void;
+};
+
+export const useAdminChallengesList = ({
+  onError,
+}: UseAdminChallengesListOptions = {}) => {
+  const [challenges, setChallenges] = useState<AdminChallenge[]>([]);
+  const [search, setSearch] = useState('');
+  const [isFetching, setIsFetching] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setIsFetching(true);
+    try {
+      const response = await listAdminChallenges();
+      if (response.success) {
+        setChallenges(Array.isArray(response.data) ? response.data : []);
+      }
+    } catch {
+      onError?.('No se pudo cargar la lista de retos.');
+    } finally {
+      setIsFetching(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const filteredChallenges = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return challenges;
+    return challenges.filter((item) =>
+      item.title.toLowerCase().includes(term),
+    );
+  }, [challenges, search]);
+
+  return { filteredChallenges, isFetching, refresh, search, setSearch };
+};

--- a/frontend/src/features/admin/pages/AdminChallengesPage/AdminChallengesPage.css
+++ b/frontend/src/features/admin/pages/AdminChallengesPage/AdminChallengesPage.css
@@ -1,0 +1,89 @@
+.admin-challenges-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-challenges-page__header {
+  margin-bottom: 0.25rem;
+}
+
+.admin-challenges-page__eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.admin-challenges-page__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #1e293b;
+}
+
+.admin-challenges-page__description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #64748b;
+}
+
+.admin-challenges-page__loading {
+  text-align: center;
+  color: #94a3b8;
+  padding: 2rem 1rem;
+  font-size: 0.9rem;
+}
+
+.admin-challenges-page__notification {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.35rem;
+  border-radius: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+  z-index: 60;
+  animation: admin-challenges-notification-fade 0.35s ease;
+}
+
+.admin-challenges-page__notification-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.admin-challenges-page__notification-message {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.admin-challenges-page__notification--success {
+  background: linear-gradient(135deg, #14b8a6, #0ea5e9);
+}
+
+.admin-challenges-page__notification--error {
+  background: linear-gradient(135deg, #ef4444, #b91c1c);
+}
+
+@keyframes admin-challenges-notification-fade {
+  from {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/features/admin/pages/AdminChallengesPage/AdminChallengesPage.tsx
+++ b/frontend/src/features/admin/pages/AdminChallengesPage/AdminChallengesPage.tsx
@@ -1,0 +1,300 @@
+import type { AxiosError } from 'axios';
+import type { FormEvent } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  createAdminChallenge,
+  updateAdminChallenge,
+  updateAdminChallengeAmount,
+  deleteAdminChallenge,
+} from '../../api/challenges.api';
+import { ChallengesToolbar } from '../../components/challenges/ChallengesToolbar/ChallengesToolbar';
+import { ChallengesGrid } from '../../components/challenges/ChallengesGrid/ChallengesGrid';
+import { ChallengeForm } from '../../components/challenges/ChallengeForm/ChallengeForm';
+import { UpdateAmountModal } from '../../components/challenges/UpdateAmountModal/UpdateAmountModal';
+import { ConfirmModal } from '../../components/shared/ConfirmModal/ConfirmModal';
+import { useAdminChallengesList } from '../../hooks/useAdminChallengesList';
+import type {
+  AdminChallenge,
+  ChallengeFormData,
+} from '../../types/challenges.types';
+import './AdminChallengesPage.css';
+
+type NotificationType = 'success' | 'error';
+type NotificationState = { message: string; type: NotificationType };
+
+const initialFormState: ChallengeFormData = {
+  title: '',
+  description: '',
+  targetAmount: '',
+  currentAmount: '0',
+  isActive: true,
+};
+
+export const AdminChallengesPage = () => {
+  const [formData, setFormData] = useState(initialFormState);
+  const [formMode, setFormMode] = useState<'create' | 'edit'>('create');
+  const [selectedChallenge, setSelectedChallenge] = useState<AdminChallenge | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [notification, setNotification] = useState<NotificationState | null>(null);
+  const [formFeedback, setFormFeedback] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AdminChallenge | null>(null);
+  const [pendingAmount, setPendingAmount] = useState<AdminChallenge | null>(null);
+
+  const showNotification = useCallback(
+    (message: string, type: NotificationType) => {
+      setNotification({ message, type });
+    },
+    [],
+  );
+
+  const handleListError = useCallback(
+    (message: string) => showNotification(message, 'error'),
+    [showNotification],
+  );
+
+  const { filteredChallenges, isFetching, refresh, search, setSearch } =
+    useAdminChallengesList({ onError: handleListError });
+
+  useEffect(() => {
+    if (!notification) return undefined;
+    const timer = setTimeout(() => setNotification(null), 2500);
+    return () => clearTimeout(timer);
+  }, [notification]);
+
+  const resetForm = () => {
+    setFormData(initialFormState);
+    setFormMode('create');
+    setSelectedChallenge(null);
+    setFormFeedback(null);
+  };
+
+  const handleNew = () => {
+    resetForm();
+    setIsFormOpen(true);
+  };
+
+  const handleEdit = (challenge: AdminChallenge) => {
+    resetForm();
+    setSelectedChallenge(challenge);
+    setFormMode('edit');
+    setFormData({
+      title: challenge.title,
+      description: challenge.description,
+      targetAmount: challenge.targetAmount.toString(),
+      currentAmount: challenge.currentAmount.toString(),
+      isActive: challenge.isActive,
+    });
+    setIsFormOpen(true);
+  };
+
+  const handleCloseForm = () => {
+    setIsFormOpen(false);
+    resetForm();
+  };
+
+  const handleFieldChange = (
+    field: keyof ChallengeFormData,
+    value: string | boolean,
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    setFormFeedback(null);
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const title = formData.title.trim();
+    const description = formData.description.trim();
+    const targetAmount = Number(formData.targetAmount);
+    const currentAmount = Number(formData.currentAmount);
+
+    if (!title) {
+      setFormFeedback('El título es obligatorio.');
+      return;
+    }
+    if (!description) {
+      setFormFeedback('La descripción es obligatoria.');
+      return;
+    }
+    if (!Number.isInteger(targetAmount) || targetAmount <= 0) {
+      setFormFeedback('El monto objetivo debe ser un entero mayor que 0.');
+      return;
+    }
+    if (!Number.isInteger(currentAmount) || currentAmount < 0) {
+      setFormFeedback('El monto actual debe ser un entero no negativo.');
+      return;
+    }
+    if (currentAmount > targetAmount) {
+      setFormFeedback('El monto actual no puede superar el objetivo.');
+      return;
+    }
+
+    setIsProcessing(true);
+    setFormFeedback(null);
+
+    try {
+      const payload = {
+        title,
+        description,
+        targetAmount,
+        currentAmount,
+        isActive: formData.isActive,
+      };
+
+      const response =
+        formMode === 'create'
+          ? await createAdminChallenge(payload)
+          : await updateAdminChallenge({ id: selectedChallenge!.id, ...payload });
+
+      if (response.success) {
+        showNotification(
+          response.message || (formMode === 'create' ? 'Reto creado.' : 'Reto actualizado.'),
+          'success',
+        );
+        await refresh();
+        handleCloseForm();
+      } else {
+        setFormFeedback(response.message || 'No se pudo guardar el reto.');
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      setFormFeedback(
+        axiosError.response?.data?.message || 'Error al guardar el reto.',
+      );
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleRequestDelete = (challenge: AdminChallenge) => {
+    setPendingDelete(challenge);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDelete) return;
+    setIsProcessing(true);
+
+    try {
+      const response = await deleteAdminChallenge(pendingDelete.id);
+      if (response.success) {
+        showNotification(response.message || 'Reto eliminado.', 'success');
+        await refresh();
+      } else {
+        showNotification(response.message || 'No se pudo eliminar el reto.', 'error');
+      }
+    } catch {
+      showNotification('Error al eliminar el reto.', 'error');
+    } finally {
+      setIsProcessing(false);
+      setPendingDelete(null);
+    }
+  };
+
+  const handleRequestUpdateAmount = (challenge: AdminChallenge) => {
+    setPendingAmount(challenge);
+  };
+
+  const handleConfirmUpdateAmount = async (currentAmount: number) => {
+    if (!pendingAmount) return;
+    setIsProcessing(true);
+
+    try {
+      const response = await updateAdminChallengeAmount({
+        id: pendingAmount.id,
+        currentAmount,
+      });
+      if (response.success) {
+        showNotification(response.message || 'Monto actualizado.', 'success');
+        await refresh();
+      } else {
+        showNotification(response.message || 'No se pudo actualizar el monto.', 'error');
+      }
+    } catch {
+      showNotification('Error al actualizar el monto.', 'error');
+    } finally {
+      setIsProcessing(false);
+      setPendingAmount(null);
+    }
+  };
+
+  return (
+    <section className="admin-challenges-page">
+      {notification && (
+        <div
+          className={`admin-challenges-page__notification admin-challenges-page__notification--${notification.type}`}
+          role="status"
+        >
+          <span className="admin-challenges-page__notification-icon" aria-hidden="true">
+            {notification.type === 'success' ? '✓' : '⚠'}
+          </span>
+          <span className="admin-challenges-page__notification-message">
+            {notification.message}
+          </span>
+        </div>
+      )}
+
+      <header className="admin-challenges-page__header">
+        <p className="admin-challenges-page__eyebrow">Panel de administración</p>
+        <h1 className="admin-challenges-page__title">Gestión de retos</h1>
+        <p className="admin-challenges-page__description">
+          Crea, edita y gestiona los retos solidarios del proyecto.
+        </p>
+      </header>
+
+      <ChallengesToolbar
+        search={search}
+        onSearchChange={setSearch}
+        onNew={handleNew}
+      />
+
+      <ChallengeForm
+        isOpen={isFormOpen}
+        formMode={formMode}
+        formData={formData}
+        isProcessing={isProcessing}
+        feedback={formFeedback}
+        onFieldChange={handleFieldChange}
+        onSubmit={handleFormSubmit}
+        onClose={handleCloseForm}
+      />
+
+      {isFetching ? (
+        <p className="admin-challenges-page__loading">Cargando retos...</p>
+      ) : (
+        <ChallengesGrid
+          challenges={filteredChallenges}
+          onEdit={handleEdit}
+          onUpdateAmount={handleRequestUpdateAmount}
+          onDelete={handleRequestDelete}
+        />
+      )}
+
+      <UpdateAmountModal
+        isOpen={Boolean(pendingAmount)}
+        challenge={pendingAmount}
+        isProcessing={isProcessing}
+        onConfirm={handleConfirmUpdateAmount}
+        onCancel={() => setPendingAmount(null)}
+      />
+
+      <ConfirmModal
+        isOpen={Boolean(pendingDelete)}
+        title="Eliminar reto"
+        description={
+          pendingDelete ? (
+            <>
+              ¿Seguro que quieres eliminar <strong>{pendingDelete.title}</strong>?
+              Esta acción archivará el reto.
+            </>
+          ) : undefined
+        }
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDelete(null)}
+        isProcessing={isProcessing}
+      />
+    </section>
+  );
+};

--- a/frontend/src/features/admin/types/challenges.types.ts
+++ b/frontend/src/features/admin/types/challenges.types.ts
@@ -1,0 +1,36 @@
+export type AdminChallenge = {
+  id: number;
+  title: string;
+  description: string;
+  targetAmount: number;
+  currentAmount: number;
+  isActive: boolean;
+  deletedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateChallengePayload = {
+  title: string;
+  description: string;
+  targetAmount: number;
+  currentAmount?: number;
+  isActive?: boolean;
+};
+
+export type UpdateChallengePayload = Partial<CreateChallengePayload> & {
+  id: number;
+};
+
+export type UpdateChallengeAmountPayload = {
+  id: number;
+  currentAmount: number;
+};
+
+export type ChallengeFormData = {
+  title: string;
+  description: string;
+  targetAmount: string;
+  currentAmount: string;
+  isActive: boolean;
+};

--- a/frontend/src/router/app.router.tsx
+++ b/frontend/src/router/app.router.tsx
@@ -3,6 +3,7 @@ import { HomePage } from '../features/home/pages/HomePage/HomePage';
 import { AuthPage } from '../features/auth/pages/AuthPage/AuthPage';
 import { ResetPasswordPage } from '../features/auth/pages/ResetPasswordPage/ResetPasswordPage';
 import { AdminLayout } from '../features/admin/components/layout/AdminLayout/AdminLayout';
+import { AdminChallengesPage } from '../features/admin/pages/AdminChallengesPage/AdminChallengesPage';
 import { AdminDashboardPage } from '../features/admin/pages/AdminDashboardPage/AdminDashboardPage';
 import { AdminHumanBooksPage } from '../features/admin/pages/AdminHumanBooksPage/AdminHumanBooksPage';
 import { AdminNewsPage } from '../features/admin/pages/AdminNewsPage/AdminNewsPage';
@@ -74,7 +75,7 @@ export const appRouter = createBrowserRouter([
       },
       {
         path: 'retos',
-        element: <AdminSectionPage section="Retos" />,
+        element: <AdminChallengesPage />,
       },
       {
         path: 'libros',


### PR DESCRIPTION
CRUD completo de retos solidarios en `/admin/retos`, reemplazando el placeholder.

## Backend
- Modelo `Challenge` con soft delete e índice en `deletedAt`
- 5 endpoints admin protegidos (JWT + ADMIN): listar, crear, editar, actualizar monto, eliminar
- Validaciones: `targetAmount > 0`, `currentAmount <= targetAmount`

## Frontend
- Cards con título, estado, montos y barra de progreso
- Modal de creación/edición (incluye `description`)
- Modal rápido de actualización de monto
- Confirmación de eliminación
- Reutiliza componentes shared existentes

## Otros
- `.gitignore` para `uploads/human-books/`