### PR TITLE
HU-39: Base técnica del chatbot (core backend + widget inicial frontend)

### DIFF
--- a/backend/prisma/migrations/20260401133500_hu39_add_chatbot_core/migration.sql
+++ b/backend/prisma/migrations/20260401133500_hu39_add_chatbot_core/migration.sql
@@ -1,0 +1,172 @@
+-- CreateEnum
+CREATE TYPE "ChatChannel" AS ENUM ('WEB');
+
+-- CreateEnum
+CREATE TYPE "ChatMessageRole" AS ENUM ('USER', 'BOT');
+
+-- CreateEnum
+CREATE TYPE "ChatReplyType" AS ENUM ('DIRECT_ANSWER', 'CLARIFICATION', 'FALLBACK');
+
+-- CreateTable
+CREATE TABLE "ChatbotIntent" (
+    "id" SERIAL NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChatbotIntent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatbotIntentPhrase" (
+    "id" SERIAL NOT NULL,
+    "intentId" INTEGER NOT NULL,
+    "text" TEXT NOT NULL,
+    "language" TEXT NOT NULL DEFAULT 'es',
+    "weight" DOUBLE PRECISION NOT NULL DEFAULT 1,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChatbotIntentPhrase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "KnowledgeItem" (
+    "id" SERIAL NOT NULL,
+    "intentId" INTEGER,
+    "questionCanonical" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "tags" JSONB NOT NULL,
+    "route" TEXT,
+    "ctaLinks" JSONB NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "KnowledgeItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatSession" (
+    "id" SERIAL NOT NULL,
+    "sessionKey" TEXT NOT NULL,
+    "userId" INTEGER,
+    "channel" "ChatChannel" NOT NULL DEFAULT 'WEB',
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastMessageAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isClosed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChatSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatMessage" (
+    "id" SERIAL NOT NULL,
+    "sessionId" INTEGER NOT NULL,
+    "role" "ChatMessageRole" NOT NULL,
+    "messageText" TEXT NOT NULL,
+    "normalizedText" TEXT,
+    "detectedIntentCode" TEXT,
+    "replyType" "ChatReplyType",
+    "confidence" DOUBLE PRECISION,
+    "meta" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ChatMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UnresolvedQuestion" (
+    "id" SERIAL NOT NULL,
+    "normalizedText" TEXT NOT NULL,
+    "sampleText" TEXT NOT NULL,
+    "pageContext" TEXT,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "occurrences" INTEGER NOT NULL DEFAULT 1,
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedById" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UnresolvedQuestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatbotIntent_code_key" ON "ChatbotIntent"("code");
+
+-- CreateIndex
+CREATE INDEX "ChatbotIntent_isActive_idx" ON "ChatbotIntent"("isActive");
+
+-- CreateIndex
+CREATE INDEX "ChatbotIntent_priority_idx" ON "ChatbotIntent"("priority");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatbotIntentPhrase_intentId_text_language_key" ON "ChatbotIntentPhrase"("intentId", "text", "language");
+
+-- CreateIndex
+CREATE INDEX "ChatbotIntentPhrase_intentId_idx" ON "ChatbotIntentPhrase"("intentId");
+
+-- CreateIndex
+CREATE INDEX "ChatbotIntentPhrase_isActive_idx" ON "ChatbotIntentPhrase"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "KnowledgeItem_questionCanonical_key" ON "KnowledgeItem"("questionCanonical");
+
+-- CreateIndex
+CREATE INDEX "KnowledgeItem_intentId_idx" ON "KnowledgeItem"("intentId");
+
+-- CreateIndex
+CREATE INDEX "KnowledgeItem_isActive_idx" ON "KnowledgeItem"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatSession_sessionKey_key" ON "ChatSession"("sessionKey");
+
+-- CreateIndex
+CREATE INDEX "ChatSession_userId_idx" ON "ChatSession"("userId");
+
+-- CreateIndex
+CREATE INDEX "ChatSession_isClosed_idx" ON "ChatSession"("isClosed");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_sessionId_createdAt_idx" ON "ChatMessage"("sessionId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_detectedIntentCode_idx" ON "ChatMessage"("detectedIntentCode");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_replyType_idx" ON "ChatMessage"("replyType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UnresolvedQuestion_normalizedText_key" ON "UnresolvedQuestion"("normalizedText");
+
+-- CreateIndex
+CREATE INDEX "UnresolvedQuestion_occurrences_idx" ON "UnresolvedQuestion"("occurrences");
+
+-- CreateIndex
+CREATE INDEX "UnresolvedQuestion_resolvedAt_idx" ON "UnresolvedQuestion"("resolvedAt");
+
+-- CreateIndex
+CREATE INDEX "UnresolvedQuestion_lastSeenAt_idx" ON "UnresolvedQuestion"("lastSeenAt");
+
+-- AddForeignKey
+ALTER TABLE "ChatbotIntentPhrase" ADD CONSTRAINT "ChatbotIntentPhrase_intentId_fkey" FOREIGN KEY ("intentId") REFERENCES "ChatbotIntent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "KnowledgeItem" ADD CONSTRAINT "KnowledgeItem_intentId_fkey" FOREIGN KEY ("intentId") REFERENCES "ChatbotIntent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatSession" ADD CONSTRAINT "ChatSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "ChatSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UnresolvedQuestion" ADD CONSTRAINT "UnresolvedQuestion_resolvedById_fkey" FOREIGN KEY ("resolvedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,21 @@ enum SuperheroStatus {
   HIDDEN
 }
 
+enum ChatChannel {
+  WEB
+}
+
+enum ChatMessageRole {
+  USER
+  BOT
+}
+
+enum ChatReplyType {
+  DIRECT_ANSWER
+  CLARIFICATION
+  FALLBACK
+}
+
 model User {
   id                       Int       @id @default(autoincrement())
   email                    String    @unique
@@ -36,6 +51,8 @@ model User {
   createdNews              News[]
   createdSuperheroes       Superhero[]
   createdHumanBooks        HumanBook[]
+  chatSessions             ChatSession[]
+  resolvedUnresolved       UnresolvedQuestion[] @relation("UnresolvedResolvedBy")
 }
 
 
@@ -130,4 +147,107 @@ model Challenge {
   updatedAt     DateTime  @updatedAt
 
   @@index([deletedAt])
+}
+
+model ChatbotIntent {
+  id             Int                 @id @default(autoincrement())
+  code           String              @unique
+  name           String
+  description    String              @db.Text
+  priority       Int                 @default(0)
+  isActive       Boolean             @default(true)
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+  phrases        ChatbotIntentPhrase[]
+  knowledgeItems KnowledgeItem[]
+
+  @@index([isActive])
+  @@index([priority])
+}
+
+model ChatbotIntentPhrase {
+  id        Int           @id @default(autoincrement())
+  intentId  Int
+  text      String
+  language  String        @default("es")
+  weight    Float         @default(1)
+  isActive  Boolean       @default(true)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  intent    ChatbotIntent @relation(fields: [intentId], references: [id], onDelete: Cascade)
+
+  @@unique([intentId, text, language])
+  @@index([intentId])
+  @@index([isActive])
+}
+
+model KnowledgeItem {
+  id                Int            @id @default(autoincrement())
+  intentId          Int?
+  questionCanonical String         @unique
+  answer            String         @db.Text
+  tags              Json
+  route             String?
+  ctaLinks          Json
+  isActive          Boolean        @default(true)
+  createdAt         DateTime       @default(now())
+  updatedAt         DateTime       @updatedAt
+  intent            ChatbotIntent? @relation(fields: [intentId], references: [id], onDelete: SetNull)
+
+  @@index([intentId])
+  @@index([isActive])
+}
+
+model ChatSession {
+  id            Int           @id @default(autoincrement())
+  sessionKey    String        @unique
+  userId        Int?
+  channel       ChatChannel   @default(WEB)
+  startedAt     DateTime      @default(now())
+  lastMessageAt DateTime      @default(now())
+  isClosed      Boolean       @default(false)
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  user          User?         @relation(fields: [userId], references: [id], onDelete: SetNull)
+  messages      ChatMessage[]
+
+  @@index([userId])
+  @@index([isClosed])
+}
+
+model ChatMessage {
+  id                 Int             @id @default(autoincrement())
+  sessionId          Int
+  role               ChatMessageRole
+  messageText        String          @db.Text
+  normalizedText     String?
+  detectedIntentCode String?
+  replyType          ChatReplyType?
+  confidence         Float?
+  meta               Json?
+  createdAt          DateTime        @default(now())
+  session            ChatSession     @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  @@index([sessionId, createdAt])
+  @@index([detectedIntentCode])
+  @@index([replyType])
+}
+
+model UnresolvedQuestion {
+  id             Int       @id @default(autoincrement())
+  normalizedText String    @unique
+  sampleText     String    @db.Text
+  pageContext    String?
+  firstSeenAt    DateTime  @default(now())
+  lastSeenAt     DateTime  @default(now())
+  occurrences    Int       @default(1)
+  resolvedAt     DateTime?
+  resolvedById   Int?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  resolvedBy     User?     @relation("UnresolvedResolvedBy", fields: [resolvedById], references: [id], onDelete: SetNull)
+
+  @@index([occurrences])
+  @@index([resolvedAt])
+  @@index([lastSeenAt])
 }

--- a/backend/prisma/seeds/chatbot-knowledge.seed.ts
+++ b/backend/prisma/seeds/chatbot-knowledge.seed.ts
@@ -1,0 +1,125 @@
+/**
+ * Seed inicial de conocimiento para chatbot (HU-39).
+ *
+ * Estrategia:
+ * - Idempotente por upsert.
+ * - Intents por `code`.
+ * - Frases por unique compuesto (`intentId`, `text`, `language`).
+ * - Knowledge por `questionCanonical`.
+ */
+
+import type { Prisma, PrismaClient } from '../../generated/prisma/client';
+import {
+  CHATBOT_SEED_INTENTS,
+  CHATBOT_SEED_INTENT_PHRASES,
+  CHATBOT_SEED_KNOWLEDGE_ITEMS,
+} from '../../src/chatbot/seed/chatbot-seed.source';
+
+export async function seedChatbotKnowledge(prisma: PrismaClient) {
+  console.log('Seeding chatbot base (intents, phrases y knowledge)...');
+
+  const intentMap = new Map<string, number>();
+
+  for (const intent of CHATBOT_SEED_INTENTS) {
+    const savedIntent = await prisma.chatbotIntent.upsert({
+      where: { code: intent.code },
+      update: {
+        name: intent.name,
+        description: intent.description,
+        priority: intent.priority,
+        isActive: intent.isActive,
+      },
+      create: {
+        code: intent.code,
+        name: intent.name,
+        description: intent.description,
+        priority: intent.priority,
+        isActive: intent.isActive,
+      },
+    });
+
+    intentMap.set(savedIntent.code, savedIntent.id);
+  }
+
+  let phrasesCreatedOrUpdated = 0;
+
+  for (const phrase of CHATBOT_SEED_INTENT_PHRASES) {
+    const intentId = intentMap.get(phrase.intentCode);
+
+    if (!intentId) {
+      console.warn(
+        `   Intent no encontrado para frase: "${phrase.text}" (${phrase.intentCode})`,
+      );
+      continue;
+    }
+
+    await prisma.chatbotIntentPhrase.upsert({
+      where: {
+        intentId_text_language: {
+          intentId,
+          text: phrase.text,
+          language: phrase.language,
+        },
+      },
+      update: {
+        weight: phrase.weight,
+        isActive: phrase.isActive,
+      },
+      create: {
+        intentId,
+        text: phrase.text,
+        language: phrase.language,
+        weight: phrase.weight,
+        isActive: phrase.isActive,
+      },
+    });
+
+    phrasesCreatedOrUpdated += 1;
+  }
+
+  let knowledgeCreatedOrUpdated = 0;
+
+  for (const item of CHATBOT_SEED_KNOWLEDGE_ITEMS) {
+    const intentId = intentMap.get(item.intentCode);
+
+    if (!intentId) {
+      console.warn(
+        `   Intent no encontrado para knowledge item: "${item.questionCanonical}" (${item.intentCode})`,
+      );
+      continue;
+    }
+
+    const tagsJson = item.tags as unknown as Prisma.InputJsonValue;
+    const ctaLinksJson = item.ctaLinks as unknown as Prisma.InputJsonValue;
+
+    await prisma.knowledgeItem.upsert({
+      where: {
+        questionCanonical: item.questionCanonical,
+      },
+      update: {
+        intentId,
+        answer: item.answer,
+        tags: tagsJson,
+        route: item.route,
+        ctaLinks: ctaLinksJson,
+        isActive: item.isActive,
+      },
+      create: {
+        intentId,
+        questionCanonical: item.questionCanonical,
+        answer: item.answer,
+        tags: tagsJson,
+        route: item.route,
+        ctaLinks: ctaLinksJson,
+        isActive: item.isActive,
+      },
+    });
+
+    knowledgeCreatedOrUpdated += 1;
+  }
+
+  console.log(`   Intents creados/verificados: ${intentMap.size}`);
+  console.log(`   Frases creadas/actualizadas: ${phrasesCreatedOrUpdated}`);
+  console.log(`   Knowledge items creados/actualizados: ${knowledgeCreatedOrUpdated}`);
+  console.log('Chatbot base seeding completado\n');
+}

--- a/backend/prisma/seeds/seed.ts
+++ b/backend/prisma/seeds/seed.ts
@@ -11,6 +11,7 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import { seedRoles } from './roles.seed';
 import { seedAdminUser } from './admin-user.seed';
 import { seedUsersBatch } from './users-batch.seed';
+import { seedChatbotKnowledge } from './chatbot-knowledge.seed';
 
 const prisma = new PrismaClient({
   adapter: new PrismaPg({
@@ -31,6 +32,9 @@ async function main() {
   // 3. Seed de batch de usuarios fake
   await seedUsersBatch(prisma);
 
+  // 4. Seed base de chatbot (HU-39)
+  await seedChatbotKnowledge(prisma);
+
   console.log('='.repeat(50));
   console.log('Seeding completado exitosamente!\n');
   console.log('Resumen de datos creados:');
@@ -38,6 +42,7 @@ async function main() {
   console.log('   - Admin: admin@proclade.local');
   console.log('   - User: user@proclade.local');
   console.log('   - Batch: 20 usuarios fake (test.user.XXX@test.com)');
+  console.log('   - Chatbot: intents, frases y knowledge inicial');
   console.log('\nTip: Las contraseñas de prueba son:');
   console.log('   - Admin: Admin123!');
   console.log('   - User: User123!');

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { ChatbotModule } from './chatbot/chatbot.module';
 import { ChallengesModule } from './challenges/challenges.module';
 import { HumanBooksModule } from './human-books/human-books.module';
 import { NewsModule } from './news/news.module';
@@ -19,6 +20,7 @@ import { UsersModule } from './users/users.module';
     PrismaModule,
     UsersModule,
     NewsModule,
+    ChatbotModule,
     RegionsModule,
     SuperheroesModule,
     HumanBooksModule,

--- a/backend/src/chatbot/chatbot-orchestrator.service.ts
+++ b/backend/src/chatbot/chatbot-orchestrator.service.ts
@@ -1,0 +1,247 @@
+import { Injectable } from '@nestjs/common';
+import { ChatReplyType, type Prisma } from 'generated/prisma/client';
+import { ChatbotSessionService } from './chatbot-session.service';
+import { KnowledgeBaseService } from './knowledge-base.service';
+import { UnresolvedQuestionService } from './unresolved-question.service';
+import type {
+  ChatbotReplyData,
+  KnowledgeCandidate,
+  ScoredCandidate,
+} from './types/chatbot.types';
+
+type SendMessagePayload = {
+  message: string;
+  sessionId?: string;
+  pageContext?: string;
+};
+
+const DIRECT_ANSWER_THRESHOLD = 0.72;
+const CLARIFICATION_THRESHOLD = 0.45;
+
+@Injectable()
+export class ChatbotOrchestratorService {
+  constructor(
+    private readonly chatbotSessionService: ChatbotSessionService,
+    private readonly knowledgeBaseService: KnowledgeBaseService,
+    private readonly unresolvedQuestionService: UnresolvedQuestionService,
+  ) {}
+
+  async createOrReuseSession(sessionId?: string) {
+    const session =
+      await this.chatbotSessionService.resolveOrCreateSession(sessionId);
+
+    return {
+      message: 'Sesión del chatbot preparada correctamente',
+      sessionId: session.sessionKey,
+    };
+  }
+
+  async sendMessage(payload: SendMessagePayload) {
+    const normalizedText = this.normalizeText(payload.message);
+    const session = await this.chatbotSessionService.resolveOrCreateSession(
+      payload.sessionId,
+    );
+
+    await this.chatbotSessionService.saveUserMessage(
+      session.id,
+      payload.message,
+      normalizedText,
+    );
+
+    const candidates = await this.knowledgeBaseService.getCandidates();
+    const scoredCandidates = this.rankCandidates(normalizedText, candidates);
+    const bestMatch = scoredCandidates[0];
+
+    const reply = this.buildReply(
+      session.sessionKey,
+      bestMatch,
+      scoredCandidates,
+    );
+
+    if (reply.replyType === ChatReplyType.FALLBACK) {
+      await this.unresolvedQuestionService.register({
+        normalizedText,
+        sampleText: payload.message,
+        pageContext: payload.pageContext,
+      });
+    }
+
+    const meta: Prisma.InputJsonValue = {
+      pageContext: payload.pageContext ?? null,
+      suggestions: reply.suggestions,
+      ctaLinks: reply.ctaLinks,
+    };
+
+    await this.chatbotSessionService.saveBotMessage(session.id, {
+      messageText: reply.answer,
+      detectedIntentCode: reply.detectedIntentCode,
+      replyType: reply.replyType,
+      confidence: reply.confidence,
+      meta,
+    });
+
+    await this.chatbotSessionService.touchSession(session.id);
+
+    return {
+      message: 'Respuesta del chatbot generada correctamente',
+      ...reply,
+    };
+  }
+
+  async getHealth() {
+    const candidates = await this.knowledgeBaseService.getCandidates();
+
+    return {
+      message: 'Chatbot operativo',
+      status: 'ok',
+      totalKnowledgeItems: candidates.length,
+      thresholds: {
+        directAnswer: DIRECT_ANSWER_THRESHOLD,
+        clarification: CLARIFICATION_THRESHOLD,
+      },
+    };
+  }
+
+  private buildReply(
+    sessionId: string,
+    bestMatch: ScoredCandidate | undefined,
+    rankedCandidates: ScoredCandidate[],
+  ): ChatbotReplyData {
+    if (!bestMatch || bestMatch.score < CLARIFICATION_THRESHOLD) {
+      return {
+        sessionId,
+        replyType: ChatReplyType.FALLBACK,
+        answer:
+          'Ahora mismo no tengo una respuesta exacta para eso. Si quieres, puedo ayudarte con información sobre donaciones, noticias, superhéroes o cómo colaborar.',
+        confidence: 0,
+        detectedIntentCode: null,
+        suggestions: this.extractSuggestions(rankedCandidates),
+        ctaLinks: [],
+      };
+    }
+
+    if (bestMatch.score < DIRECT_ANSWER_THRESHOLD) {
+      return {
+        sessionId,
+        replyType: ChatReplyType.CLARIFICATION,
+        answer:
+          'Creo que estás preguntando sobre este tema. ¿Te sirve esta respuesta o quieres que te enseñe opciones relacionadas?',
+        confidence: bestMatch.score,
+        detectedIntentCode: bestMatch.candidate.intentCode,
+        suggestions: this.extractSuggestions(rankedCandidates),
+        ctaLinks: bestMatch.candidate.ctaLinks,
+      };
+    }
+
+    return {
+      sessionId,
+      replyType: ChatReplyType.DIRECT_ANSWER,
+      answer: bestMatch.candidate.answer,
+      confidence: bestMatch.score,
+      detectedIntentCode: bestMatch.candidate.intentCode,
+      suggestions: this.extractSuggestions(rankedCandidates),
+      ctaLinks: bestMatch.candidate.ctaLinks,
+    };
+  }
+
+  private rankCandidates(
+    normalizedText: string,
+    candidates: KnowledgeCandidate[],
+  ): ScoredCandidate[] {
+    const userTokens = this.tokenize(normalizedText);
+
+    return candidates
+      .map((candidate) => ({
+        candidate,
+        score: this.calculateCandidateScore(
+          normalizedText,
+          userTokens,
+          candidate,
+        ),
+      }))
+      .sort((left, right) => right.score - left.score)
+      .slice(0, 5);
+  }
+
+  private calculateCandidateScore(
+    normalizedText: string,
+    userTokens: string[],
+    candidate: KnowledgeCandidate,
+  ) {
+    const canonicalScore = this.calculateTextSimilarity(
+      normalizedText,
+      this.normalizeText(candidate.questionCanonical),
+    );
+
+    const phraseScore = candidate.phrases.reduce((best, phrase) => {
+      const value = this.calculateTextSimilarity(
+        normalizedText,
+        this.normalizeText(phrase),
+      );
+      return value > best ? value : best;
+    }, 0);
+
+    const tagsText = candidate.tags.join(' ');
+    const tagScore = this.calculateTextSimilarity(
+      normalizedText,
+      this.normalizeText(tagsText),
+      userTokens,
+    );
+
+    return canonicalScore * 0.5 + phraseScore * 0.35 + tagScore * 0.15;
+  }
+
+  private calculateTextSimilarity(
+    userText: string,
+    candidateText: string,
+    userTokensInput?: string[],
+  ) {
+    if (userText === candidateText) {
+      return 1;
+    }
+
+    if (candidateText.includes(userText) || userText.includes(candidateText)) {
+      return 0.92;
+    }
+
+    const userTokens = userTokensInput ?? this.tokenize(userText);
+    const candidateTokens = this.tokenize(candidateText);
+
+    if (userTokens.length === 0 || candidateTokens.length === 0) {
+      return 0;
+    }
+
+    const candidateTokenSet = new Set(candidateTokens);
+    const matchedTokens = userTokens.filter((token) =>
+      candidateTokenSet.has(token),
+    );
+
+    return (
+      matchedTokens.length / Math.max(userTokens.length, candidateTokens.length)
+    );
+  }
+
+  private extractSuggestions(candidates: ScoredCandidate[]) {
+    return candidates
+      .filter((item) => item.score > 0.2)
+      .slice(0, 3)
+      .map((item) => item.candidate.questionCanonical);
+  }
+
+  private tokenize(text: string) {
+    return text
+      .split(' ')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 1);
+  }
+
+  private normalizeText(text: string) {
+    return text
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9 ]+/g, ' ')
+      .replace(/\s+/g, ' ');
+  }
+}

--- a/backend/src/chatbot/chatbot-session.service.ts
+++ b/backend/src/chatbot/chatbot-session.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ChatMessageRole,
+  ChatReplyType,
+  type ChatSession,
+  type Prisma,
+} from 'generated/prisma/client';
+import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ChatbotSessionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async resolveOrCreateSession(sessionId?: string): Promise<ChatSession> {
+    if (sessionId) {
+      const existingSession = await this.prisma.chatSession.findFirst({
+        where: {
+          sessionKey: sessionId,
+          isClosed: false,
+        },
+      });
+
+      if (existingSession) {
+        return existingSession;
+      }
+    }
+
+    return this.prisma.chatSession.create({
+      data: {
+        sessionKey: randomUUID(),
+      },
+    });
+  }
+
+  async saveUserMessage(
+    sessionId: number,
+    messageText: string,
+    normalizedText: string,
+  ) {
+    return this.prisma.chatMessage.create({
+      data: {
+        sessionId,
+        role: ChatMessageRole.USER,
+        messageText,
+        normalizedText,
+      },
+    });
+  }
+
+  async saveBotMessage(
+    sessionId: number,
+    payload: {
+      messageText: string;
+      detectedIntentCode: string | null;
+      replyType: ChatReplyType;
+      confidence: number;
+      meta?: Prisma.InputJsonValue;
+    },
+  ) {
+    return this.prisma.chatMessage.create({
+      data: {
+        sessionId,
+        role: ChatMessageRole.BOT,
+        messageText: payload.messageText,
+        detectedIntentCode: payload.detectedIntentCode,
+        replyType: payload.replyType,
+        confidence: payload.confidence,
+        meta: payload.meta,
+      },
+    });
+  }
+
+  async touchSession(sessionId: number) {
+    return this.prisma.chatSession.update({
+      where: { id: sessionId },
+      data: { lastMessageAt: new Date() },
+    });
+  }
+}

--- a/backend/src/chatbot/chatbot.controller.ts
+++ b/backend/src/chatbot/chatbot.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { ChatbotOrchestratorService } from './chatbot-orchestrator.service';
+import { CreateChatSessionDto } from './dto/create-chat-session.dto';
+import { SendChatMessageDto } from './dto/send-chat-message.dto';
+
+@Controller('chatbot')
+export class ChatbotController {
+  constructor(
+    private readonly chatbotOrchestratorService: ChatbotOrchestratorService,
+  ) {}
+
+  @Post('sessions')
+  createSession(@Body() createChatSessionDto: CreateChatSessionDto) {
+    return this.chatbotOrchestratorService.createOrReuseSession(
+      createChatSessionDto.sessionId,
+    );
+  }
+
+  @Post('message')
+  sendMessage(@Body() sendChatMessageDto: SendChatMessageDto) {
+    return this.chatbotOrchestratorService.sendMessage({
+      message: sendChatMessageDto.message,
+      sessionId: sendChatMessageDto.sessionId,
+      pageContext: sendChatMessageDto.pageContext,
+    });
+  }
+
+  @Get('health')
+  health() {
+    return this.chatbotOrchestratorService.getHealth();
+  }
+}

--- a/backend/src/chatbot/chatbot.module.ts
+++ b/backend/src/chatbot/chatbot.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ChatbotController } from './chatbot.controller';
+import { ChatbotOrchestratorService } from './chatbot-orchestrator.service';
+import { ChatbotSessionService } from './chatbot-session.service';
+import { KnowledgeBaseService } from './knowledge-base.service';
+import { UnresolvedQuestionService } from './unresolved-question.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ChatbotController],
+  providers: [
+    ChatbotOrchestratorService,
+    ChatbotSessionService,
+    KnowledgeBaseService,
+    UnresolvedQuestionService,
+  ],
+  exports: [ChatbotOrchestratorService],
+})
+export class ChatbotModule {}

--- a/backend/src/chatbot/dto/create-chat-session.dto.ts
+++ b/backend/src/chatbot/dto/create-chat-session.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsUUID } from 'class-validator';
+
+export class CreateChatSessionDto {
+  @IsOptional()
+  @IsUUID('4', { message: 'El sessionId debe ser un UUID v4 válido' })
+  sessionId?: string;
+}

--- a/backend/src/chatbot/dto/send-chat-message.dto.ts
+++ b/backend/src/chatbot/dto/send-chat-message.dto.ts
@@ -1,0 +1,27 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+export class SendChatMessageDto {
+  @IsOptional()
+  @IsUUID('4', { message: 'El sessionId debe ser un UUID v4 válido' })
+  sessionId?: string;
+
+  @IsString({ message: 'El mensaje debe ser texto' })
+  @IsNotEmpty({ message: 'El mensaje no puede estar vacío' })
+  @MaxLength(1200, {
+    message: 'El mensaje no puede superar 1200 caracteres',
+  })
+  message: string;
+
+  @IsOptional()
+  @IsString({ message: 'El contexto de página debe ser texto válido' })
+  @MaxLength(160, {
+    message: 'El contexto de página no puede superar 160 caracteres',
+  })
+  pageContext?: string;
+}

--- a/backend/src/chatbot/knowledge-base.service.ts
+++ b/backend/src/chatbot/knowledge-base.service.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@nestjs/common';
+import type { Prisma } from 'generated/prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import type { ChatbotCtaLink, KnowledgeCandidate } from './types/chatbot.types';
+
+@Injectable()
+export class KnowledgeBaseService {
+  private cachedCandidates: KnowledgeCandidate[] | null = null;
+  private cacheTimestamp = 0;
+  private readonly cacheTtlMs = 30_000;
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getCandidates(forceRefresh = false): Promise<KnowledgeCandidate[]> {
+    const now = Date.now();
+
+    if (
+      !forceRefresh &&
+      this.cachedCandidates &&
+      now - this.cacheTimestamp < this.cacheTtlMs
+    ) {
+      return this.cachedCandidates;
+    }
+
+    const rows = await this.prisma.knowledgeItem.findMany({
+      where: {
+        isActive: true,
+      },
+      include: {
+        intent: {
+          select: {
+            code: true,
+            isActive: true,
+            phrases: {
+              where: {
+                isActive: true,
+              },
+              select: {
+                text: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const candidates = rows
+      .filter((row) => row.intent?.isActive !== false)
+      .map((row) => ({
+        id: row.id,
+        intentCode: row.intent?.code ?? null,
+        questionCanonical: row.questionCanonical,
+        answer: row.answer,
+        tags: this.parseStringArray(row.tags),
+        route: row.route,
+        ctaLinks: this.parseCtaLinks(row.ctaLinks),
+        phrases: row.intent?.phrases.map((phrase) => phrase.text) ?? [],
+      }));
+
+    this.cachedCandidates = candidates;
+    this.cacheTimestamp = now;
+
+    return candidates;
+  }
+
+  invalidateCache() {
+    this.cachedCandidates = null;
+    this.cacheTimestamp = 0;
+  }
+
+  private parseStringArray(value: Prisma.JsonValue): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+
+  private parseCtaLinks(value: Prisma.JsonValue): ChatbotCtaLink[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const links: ChatbotCtaLink[] = [];
+
+    for (const rawItem of value) {
+      if (
+        typeof rawItem !== 'object' ||
+        rawItem === null ||
+        Array.isArray(rawItem)
+      ) {
+        continue;
+      }
+
+      const item = rawItem as Record<string, unknown>;
+
+      links.push({
+        label:
+          typeof item.label === 'string' ? item.label : 'Ver más información',
+        to: typeof item.to === 'string' ? item.to : '/',
+      });
+    }
+
+    return links;
+  }
+}

--- a/backend/src/chatbot/seed/chatbot-seed.source.ts
+++ b/backend/src/chatbot/seed/chatbot-seed.source.ts
@@ -1,0 +1,626 @@
+import type {
+  ChatbotSeedIntent,
+  ChatbotSeedIntentPhrase,
+  ChatbotSeedKnowledgeItem,
+} from './chatbot-seed.types';
+
+export const CHATBOT_SEED_INTENTS: ChatbotSeedIntent[] = [
+  {
+    code: 'EQUIPO_PUCH_OVERVIEW',
+    name: 'Que es Equipo PUCH',
+    description: 'Informacion general de la campana y objetivo ODS 2.',
+    priority: 100,
+    isActive: true,
+  },
+  {
+    code: 'UNIRSE_EQUIPO_PUCH',
+    name: 'Como unirse al equipo',
+    description: 'Formas de participar y sensibilizar.',
+    priority: 95,
+    isActive: true,
+  },
+  {
+    code: 'PROYECTOS_INTERNACIONALES',
+    name: 'Proyectos internacionales',
+    description: 'India, Burkina Faso y Haiti/Republica Dominicana.',
+    priority: 90,
+    isActive: true,
+  },
+  {
+    code: 'DONAR',
+    name: 'Donaciones',
+    description: 'Donacion en enlace oficial de Fundacion PROCLADE.',
+    priority: 120,
+    isActive: true,
+  },
+  {
+    code: 'COLABORAR',
+    name: 'Colaborar y voluntariado',
+    description: 'Participacion, red solidaria y apoyo economico.',
+    priority: 85,
+    isActive: true,
+  },
+  {
+    code: 'NOTICIAS',
+    name: 'Noticias del proyecto',
+    description: 'Informacion de la seccion de noticias.',
+    priority: 85,
+    isActive: true,
+  },
+  {
+    code: 'SUPERHEROES',
+    name: 'Superheroes PUCH',
+    description: 'Historias y testimonios del equipo PUCH.',
+    priority: 80,
+    isActive: true,
+  },
+  {
+    code: 'RETOS_SOLIDARIOS',
+    name: 'Retos solidarios',
+    description: 'Retos de colaboracion vinculados a hambre cero.',
+    priority: 75,
+    isActive: true,
+  },
+  {
+    code: 'BIBLIOTECAS_HUMANAS',
+    name: 'Bibliotecas humanas',
+    description: 'Proyecto educativo Personas que cuentan y te cuentan.',
+    priority: 88,
+    isActive: true,
+  },
+  {
+    code: 'DELEGACIONES',
+    name: 'Delegaciones',
+    description: 'Zonas y delegaciones del proyecto bibliotecas humanas.',
+    priority: 70,
+    isActive: true,
+  },
+  {
+    code: 'CONTACTO',
+    name: 'Contacto',
+    description: 'Canales de contacto y horario.',
+    priority: 65,
+    isActive: true,
+  },
+];
+
+export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    text: 'que es equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    text: 'que significa puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    text: 'que hace equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    text: 'de que trata personas unidas contra el hambre',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'UNIRSE_EQUIPO_PUCH',
+    text: 'como unirme al equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'UNIRSE_EQUIPO_PUCH',
+    text: 'como participar en equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'UNIRSE_EQUIPO_PUCH',
+    text: 'quiero ayudar en la campana',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'UNIRSE_EQUIPO_PUCH',
+    text: 'como puedo sensibilizar',
+    language: 'es',
+    weight: 0.8,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'donde trabaja equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'proyectos en india burkina faso haiti',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'que hacen en india',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'que hacen en burkina faso',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'que hacen en haiti republica dominicana',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'DONAR',
+    text: 'como donar',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'DONAR',
+    text: 'quiero donar',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'DONAR',
+    text: 'donde hacer una donacion',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'DONAR',
+    text: 'como aportar dinero',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'COLABORAR',
+    text: 'como colaborar',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'COLABORAR',
+    text: 'quiero hacer voluntariado',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'COLABORAR',
+    text: 'como participar en la red solidaria',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'NOTICIAS',
+    text: 'ultimas noticias',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'NOTICIAS',
+    text: 'donde ver noticias',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'NOTICIAS',
+    text: 'noticias del equipo puch',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'SUPERHEROES',
+    text: 'quienes son los superheroes',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'SUPERHEROES',
+    text: 'superheroe india',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'SUPERHEROES',
+    text: 'superheroe burkina faso',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'SUPERHEROES',
+    text: 'superheroe haiti republica dominicana',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'RETOS_SOLIDARIOS',
+    text: 'que retos hay',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'RETOS_SOLIDARIOS',
+    text: 'reto economico',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'RETOS_SOLIDARIOS',
+    text: 'una granja en 30 dias',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'BIBLIOTECAS_HUMANAS',
+    text: 'que son las bibliotecas humanas',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'BIBLIOTECAS_HUMANAS',
+    text: 'personas que cuentan y te cuentan',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'BIBLIOTECAS_HUMANAS',
+    text: 'libros humanos',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'DELEGACIONES',
+    text: 'delegaciones',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'DELEGACIONES',
+    text: 'asturias cantabria la rioja zaragoza castilla y leon madrid',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+
+  {
+    intentCode: 'CONTACTO',
+    text: 'contacto',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
+  {
+    intentCode: 'CONTACTO',
+    text: 'correo y telefono',
+    language: 'es',
+    weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'CONTACTO',
+    text: 'horario de atencion',
+    language: 'es',
+    weight: 0.8,
+    isActive: true,
+  },
+];
+
+export const CHATBOT_SEED_KNOWLEDGE_ITEMS: ChatbotSeedKnowledgeItem[] = [
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    questionCanonical: 'que es equipo puch',
+    answer:
+      'Equipo PUCH significa Personas Unidas Contra el Hambre. Es una campana de sensibilizacion y accion social impulsada junto a Fundacion PROCLADE para avanzar hacia el ODS 2 Hambre Cero.',
+    tags: ['equipo puch', 'ods 2', 'hambre cero', 'fundacion proclade'],
+    route: '/',
+    ctaLinks: [{ label: 'Ir a inicio', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'UNIRSE_EQUIPO_PUCH',
+    questionCanonical: 'como unirse al equipo puch',
+    answer:
+      'Unirse al Equipo PUCH significa sensibilizar y contar historias invisibilizadas, formar parte de una red solidaria y apoyar economicamente proyectos contra el hambre.',
+    tags: ['unirse', 'participar', 'sensibilizar', 'red solidaria'],
+    route: '/',
+    ctaLinks: [{ label: 'Ver seccion de inicio', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    questionCanonical: 'en que paises trabaja equipo puch',
+    answer:
+      'Actualmente se trabaja en India, Burkina Faso y Haiti/Republica Dominicana con proyectos de soberania y seguridad alimentaria, formacion y fortalecimiento comunitario.',
+    tags: ['india', 'burkina faso', 'haiti', 'republica dominicana'],
+    route: '/',
+    ctaLinks: [{ label: 'Ver proyectos en home', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    questionCanonical: 'que hacen en india',
+    answer:
+      'En India se apoya a mujeres Dalit con ganaderia, formacion en gestion economica y liderazgo, y talleres familiares para reforzar igualdad y convivencia.',
+    tags: ['india', 'dalit', 'ganaderia', 'liderazgo'],
+    route: '/',
+    ctaLinks: [{ label: 'Ver proyectos en home', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    questionCanonical: 'que hacen en burkina faso',
+    answer:
+      'En Koudougou se crean huertas agroecologicas con riego solar, pozos de agua y granjas comunitarias, con formacion para mujeres y jovenes.',
+    tags: ['burkina faso', 'koudougou', 'huertas', 'riego solar'],
+    route: '/',
+    ctaLinks: [{ label: 'Ver proyectos en home', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    questionCanonical: 'que hacen en haiti y republica dominicana',
+    answer:
+      'En Enriquillo y zonas de frontera se combina ayuda humanitaria inmediata con formacion para autosuficiencia y seguridad alimentaria.',
+    tags: [
+      'haiti',
+      'republica dominicana',
+      'enriquillo',
+      'seguridad alimentaria',
+    ],
+    route: '/',
+    ctaLinks: [{ label: 'Ver proyectos en home', to: '/' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'DONAR',
+    questionCanonical: 'como donar',
+    answer:
+      'La donacion se realiza en la pagina oficial de Fundacion PROCLADE, donde puedes donar por distintos metodos de pago.',
+    tags: ['donar', 'donacion', 'aporte', 'proclade'],
+    route: '/colabora',
+    ctaLinks: [
+      {
+        label: 'Ir a donar en PROCLADE',
+        to: 'https://www.fundacionproclade.org/dona/',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'DONAR',
+    questionCanonical: 'ejemplos de impacto de una donacion',
+    answer:
+      'Ejemplos orientativos de impacto: con 100 euros se puede apoyar la compra de una cabra para una mujer Dalit en India; con 20 euros, semillas para huertas en Burkina Faso; con 40 euros, apoyo alimentario en Enriquillo.',
+    tags: ['impacto', '100 euros', '20 euros', '40 euros'],
+    route: '/colabora',
+    ctaLinks: [
+      {
+        label: 'Donar ahora',
+        to: 'https://www.fundacionproclade.org/dona/',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'COLABORAR',
+    questionCanonical: 'como colaborar sin donar',
+    answer:
+      'Tambien puedes colaborar sensibilizando, difundiendo historias, participando en acciones comunitarias y sumandote a la red solidaria del proyecto.',
+    tags: ['colaborar', 'voluntariado', 'sensibilizar', 'difusion'],
+    route: '/colabora',
+    ctaLinks: [{ label: 'Ver seccion Colabora', to: '/colabora' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'COLABORAR',
+    questionCanonical: 'formulario de colaboracion',
+    answer:
+      'La pagina de colaboracion se esta ampliando progresivamente. Mientras tanto, puedes dejar tu interes de colaboracion a traves de los canales de contacto del proyecto.',
+    tags: ['formulario', 'contacto', 'colaboracion'],
+    route: '/colabora',
+    ctaLinks: [
+      { label: 'Ir a Colabora', to: '/colabora' },
+      { label: 'Ver contacto', to: '/contacto' },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'NOTICIAS',
+    questionCanonical: 'donde ver noticias del proyecto',
+    answer:
+      'Puedes consultar las noticias del proyecto en la seccion Noticias. Ahi veras publicaciones recientes, avances y testimonios.',
+    tags: ['noticias', 'actualidad', 'publicaciones'],
+    route: '/noticias',
+    ctaLinks: [{ label: 'Ir a Noticias', to: '/noticias' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'NOTICIAS',
+    questionCanonical: 'que tipo de noticias publican',
+    answer:
+      'Se publican avances de proyectos, acciones educativas, voluntariado, cooperacion y testimonios relacionados con hambre cero.',
+    tags: ['avances', 'proyectos', 'voluntariado', 'cooperacion'],
+    route: '/noticias',
+    ctaLinks: [{ label: 'Ver noticias publicadas', to: '/noticias' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'SUPERHEROES',
+    questionCanonical: 'quienes son los superheroes puch',
+    answer:
+      'Los superheroes PUCH representan a personas comprometidas que luchan contra el hambre desde sus comunidades. No son personajes de ficcion aislados, sino simbolos de accion real y colectiva.',
+    tags: ['superheroes', 'equipo puch', 'testimonios'],
+    route: '/superheroes',
+    ctaLinks: [{ label: 'Ver Superheroes', to: '/superheroes' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'SUPERHEROES',
+    questionCanonical: 'superheroes por pais',
+    answer:
+      'En la comunicacion del proyecto hay referencias especificas a superheroes vinculados a India, Burkina Faso y Haiti/Republica Dominicana, mostrando acciones reales en cada territorio.',
+    tags: ['india', 'burkina faso', 'haiti', 'testimonios'],
+    route: '/superheroes',
+    ctaLinks: [{ label: 'Abrir seccion de Superheroes', to: '/superheroes' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'RETOS_SOLIDARIOS',
+    questionCanonical: 'que retos solidarios hay',
+    answer:
+      'Uno de los retos definidos es Una granja en 30 dias, orientado a recaudar fondos para fortalecer autosuficiencia alimentaria en frontera de Haiti y Republica Dominicana.',
+    tags: ['retos', 'granja en 30 dias', 'recaudacion'],
+    route: '/colabora',
+    ctaLinks: [{ label: 'Ver Colabora', to: '/colabora' }],
+    isActive: true,
+  },
+  {
+    intentCode: 'BIBLIOTECAS_HUMANAS',
+    questionCanonical: 'que son las bibliotecas humanas',
+    answer:
+      'El proyecto Personas que cuentan y te cuentan impulsa una Biblioteca Humana donde se comparten historias reales para sensibilizar sobre las causas del hambre y promover compromiso ciudadano.',
+    tags: [
+      'bibliotecas humanas',
+      'personas que cuentan',
+      'educacion para el desarrollo',
+    ],
+    route: null,
+    ctaLinks: [
+      {
+        label: 'Delegaciones PROCLADE',
+        to: 'https://www.fundacionproclade.org/delegaciones/',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'BIBLIOTECAS_HUMANAS',
+    questionCanonical: 'que son los libros humanos',
+    answer:
+      'Los libros humanos son personas que comparten su experiencia en primera persona sobre alimentacion, cooperacion y cambio social. En la plataforma se gestionan como recursos con su contenido asociado.',
+    tags: ['libros humanos', 'recursos', 'testimonios'],
+    route: null,
+    ctaLinks: [
+      {
+        label: 'Ver delegaciones',
+        to: 'https://www.fundacionproclade.org/delegaciones/',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'DELEGACIONES',
+    questionCanonical: 'que delegaciones participan',
+    answer:
+      'En la propuesta de bibliotecas humanas se contemplan delegaciones en Asturias, Cantabria, La Rioja, Zaragoza, Castilla y Leon y Madrid.',
+    tags: [
+      'delegaciones',
+      'asturias',
+      'cantabria',
+      'la rioja',
+      'zaragoza',
+      'castilla y leon',
+      'madrid',
+    ],
+    route: null,
+    ctaLinks: [
+      {
+        label: 'Ver delegaciones PROCLADE',
+        to: 'https://www.fundacionproclade.org/delegaciones/',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'CONTACTO',
+    questionCanonical: 'como contactar',
+    answer:
+      'Puedes contactar por correo en equipo@equipopuch.org o info@fundacionproclade.org. Tambien hay telefono de contacto +34 91 000 00 00 en la informacion visible de la web.',
+    tags: ['contacto', 'correo', 'telefono', 'horario'],
+    route: null,
+    ctaLinks: [
+      {
+        label: 'Escribir a equipo@equipopuch.org',
+        to: 'mailto:equipo@equipopuch.org',
+      },
+      {
+        label: 'Escribir a info@fundacionproclade.org',
+        to: 'mailto:info@fundacionproclade.org',
+      },
+    ],
+    isActive: true,
+  },
+  {
+    intentCode: 'CONTACTO',
+    questionCanonical: 'horario de atencion',
+    answer:
+      'El horario visible actualmente es de lunes a viernes de 09:00 a 18:00. Si necesitas una respuesta formal, usa los canales de correo para dejar tu solicitud.',
+    tags: ['horario', 'atencion', 'lunes a viernes'],
+    route: null,
+    ctaLinks: [
+      {
+        label: 'Enviar correo de contacto',
+        to: 'mailto:equipo@equipopuch.org',
+      },
+    ],
+    isActive: true,
+  },
+];

--- a/backend/src/chatbot/seed/chatbot-seed.types.ts
+++ b/backend/src/chatbot/seed/chatbot-seed.types.ts
@@ -1,0 +1,30 @@
+export type ChatbotSeedIntent = {
+  code: string;
+  name: string;
+  description: string;
+  priority: number;
+  isActive: boolean;
+};
+
+export type ChatbotSeedIntentPhrase = {
+  intentCode: string;
+  text: string;
+  language: 'es';
+  weight: number;
+  isActive: boolean;
+};
+
+export type ChatbotSeedCtaLink = {
+  label: string;
+  to: string;
+};
+
+export type ChatbotSeedKnowledgeItem = {
+  intentCode: string;
+  questionCanonical: string;
+  answer: string;
+  tags: string[];
+  route: string | null;
+  ctaLinks: ChatbotSeedCtaLink[];
+  isActive: boolean;
+};

--- a/backend/src/chatbot/types/chatbot.types.ts
+++ b/backend/src/chatbot/types/chatbot.types.ts
@@ -1,0 +1,32 @@
+import { ChatReplyType } from 'generated/prisma/client';
+
+export type ChatbotCtaLink = {
+  label: string;
+  to: string;
+};
+
+export type ChatbotReplyData = {
+  sessionId: string;
+  replyType: ChatReplyType;
+  answer: string;
+  confidence: number;
+  detectedIntentCode: string | null;
+  suggestions: string[];
+  ctaLinks: ChatbotCtaLink[];
+};
+
+export type KnowledgeCandidate = {
+  id: number;
+  intentCode: string | null;
+  questionCanonical: string;
+  answer: string;
+  tags: string[];
+  route: string | null;
+  ctaLinks: ChatbotCtaLink[];
+  phrases: string[];
+};
+
+export type ScoredCandidate = {
+  candidate: KnowledgeCandidate;
+  score: number;
+};

--- a/backend/src/chatbot/unresolved-question.service.ts
+++ b/backend/src/chatbot/unresolved-question.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+type RegisterUnresolvedPayload = {
+  normalizedText: string;
+  sampleText: string;
+  pageContext?: string;
+};
+
+@Injectable()
+export class UnresolvedQuestionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async register(payload: RegisterUnresolvedPayload) {
+    return this.prisma.unresolvedQuestion.upsert({
+      where: {
+        normalizedText: payload.normalizedText,
+      },
+      update: {
+        sampleText: payload.sampleText,
+        pageContext: payload.pageContext ?? null,
+        lastSeenAt: new Date(),
+        occurrences: {
+          increment: 1,
+        },
+        // Si una pregunta vuelve a aparecer, se reabre para revisión.
+        resolvedAt: null,
+        resolvedById: null,
+      },
+      create: {
+        normalizedText: payload.normalizedText,
+        sampleText: payload.sampleText,
+        pageContext: payload.pageContext ?? null,
+      },
+    });
+  }
+}

--- a/backend/test/chatbot/chatbot.e2e-spec.ts
+++ b/backend/test/chatbot/chatbot.e2e-spec.ts
@@ -1,0 +1,186 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module';
+import { GlobalExceptionFilter } from '../../src/common/filters/global-exception.filter';
+import { TransformInterceptor } from '../../src/common/interceptors/transform.interceptor';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { seedChatbotKnowledge } from '../../prisma/seeds/chatbot-knowledge.seed';
+
+type ApiResponseBody<T> = {
+  success: boolean;
+  message: string;
+  data: T | null;
+};
+
+describe('Chatbot (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let httpServer: Parameters<typeof request>[0];
+
+  const runId = `hu39-e2e-${Date.now()}`;
+  const unknownText = `consulta desconocida ${runId} sin coincidencias`;
+  const unknownTextNormalized = normalizeText(unknownText);
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        stopAtFirstError: true,
+      }),
+    );
+    app.useGlobalInterceptors(new TransformInterceptor());
+    app.useGlobalFilters(new GlobalExceptionFilter());
+    await app.init();
+
+    prisma = app.get(PrismaService);
+    httpServer = app.getHttpServer() as Parameters<typeof request>[0];
+    await seedChatbotKnowledge(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.unresolvedQuestion.deleteMany({
+      where: {
+        normalizedText: {
+          contains: runId,
+        },
+      },
+    });
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  it('GET /chatbot/health devuelve estado operativo', async () => {
+    const response = await request(httpServer)
+      .get('/chatbot/health')
+      .expect(200);
+    const body = parseApiResponse<{
+      status: string;
+      totalKnowledgeItems: number;
+    }>(response.body);
+
+    expect(body.success).toBe(true);
+    expect(body.data?.status).toBe('ok');
+    expect((body.data?.totalKnowledgeItems ?? 0) > 0).toBe(true);
+  });
+
+  it('POST /chatbot/sessions crea o reutiliza una sesión', async () => {
+    const firstResponse = await request(httpServer)
+      .post('/chatbot/sessions')
+      .send({})
+      .expect(201);
+    const firstBody = parseApiResponse<{ sessionId: string }>(
+      firstResponse.body,
+    );
+
+    expect(firstBody.success).toBe(true);
+    expect(typeof firstBody.data?.sessionId).toBe('string');
+    expect(firstBody.data?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+
+    const secondResponse = await request(httpServer)
+      .post('/chatbot/sessions')
+      .send({
+        sessionId: firstBody.data?.sessionId,
+      })
+      .expect(201);
+    const secondBody = parseApiResponse<{ sessionId: string }>(
+      secondResponse.body,
+    );
+
+    expect(secondBody.success).toBe(true);
+    expect(secondBody.data?.sessionId).toBe(firstBody.data?.sessionId);
+  });
+
+  it('POST /chatbot/message responde y registra fallback en preguntas no resueltas', async () => {
+    const sessionResponse = await request(httpServer)
+      .post('/chatbot/sessions')
+      .send({})
+      .expect(201);
+    const sessionBody = parseApiResponse<{ sessionId: string }>(
+      sessionResponse.body,
+    );
+
+    const sessionId = sessionBody.data?.sessionId;
+    expect(typeof sessionId).toBe('string');
+
+    const knownResponse = await request(httpServer)
+      .post('/chatbot/message')
+      .send({
+        sessionId,
+        message: 'como donar',
+        pageContext: 'home',
+      })
+      .expect(201);
+    const knownBody = parseApiResponse<{
+      replyType: string;
+      answer: string;
+    }>(knownResponse.body);
+
+    expect(knownBody.success).toBe(true);
+    expect(knownBody.data?.replyType).not.toBe('FALLBACK');
+    expect((knownBody.data?.answer.length ?? 0) > 0).toBe(true);
+
+    const unknownResponse = await request(httpServer)
+      .post('/chatbot/message')
+      .send({
+        sessionId,
+        message: unknownText,
+        pageContext: 'home',
+      })
+      .expect(201);
+    const unknownBody = parseApiResponse<{ replyType: string }>(
+      unknownResponse.body,
+    );
+
+    expect(unknownBody.success).toBe(true);
+    expect(unknownBody.data?.replyType).toBe('FALLBACK');
+
+    const unresolvedRecord = await prisma.unresolvedQuestion.findUnique({
+      where: {
+        normalizedText: unknownTextNormalized,
+      },
+    });
+
+    expect(unresolvedRecord).not.toBeNull();
+    expect(unresolvedRecord?.occurrences).toBeGreaterThanOrEqual(1);
+  });
+});
+
+function normalizeText(text: string) {
+  return text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+function parseApiResponse<T>(value: unknown): ApiResponseBody<T> {
+  if (!isObject(value)) {
+    throw new Error('Respuesta API inválida: body no es un objeto');
+  }
+
+  const success = typeof value.success === 'boolean' ? value.success : false;
+  const message = typeof value.message === 'string' ? value.message : '';
+  const data = ('data' in value ? value.data : null) as T | null;
+
+  return {
+    success,
+    message,
+    data,
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/docs/08-chatbot/08.2-hu39-kb-seed-inventory.md
+++ b/docs/08-chatbot/08.2-hu39-kb-seed-inventory.md
@@ -1,0 +1,74 @@
+# HU-39 - Inventario de contenido para Seed inicial de Chatbot
+
+## Objetivo
+
+Definir una fuente trazable de conocimiento inicial para el chatbot sin inventar contenido y alineada con:
+
+1. Documentacion de cliente (ONG).
+2. Contenido ya publicado en frontend.
+3. Capacidad funcional existente en backend.
+
+---
+
+## Fuentes revisadas
+
+## Documentos cliente
+
+1. `/Users/zar0/Desktop/Assets proyecto proclade/Equipo puch.docx`
+2. `/Users/zar0/Desktop/Assets proyecto proclade/DOMINIO PROTOTIPO-BIBLIOTECAS HUMANAS.docx`
+
+## Frontend actual
+
+1. `frontend/src/features/home/content/home.content.ts`
+2. `frontend/src/features/news/mocks/news.mocks.ts`
+3. `frontend/src/router/pages/ColaboraPage.tsx`
+4. `frontend/src/router/pages/SuperheroesPage.tsx`
+5. `frontend/src/components/layout/Footer/Footer.tsx`
+
+## Backend actual
+
+1. `backend/src/news/news.controller.ts`
+2. `backend/src/superheroes/superheroes.controller.ts`
+3. `backend/src/human-books/human-books.controller.ts`
+
+---
+
+## Decision funcional para HU-39
+
+1. El chatbot no leerá documentos en runtime.
+2. La inteligencia base se cargará por `seed` desde estructuras tipadas.
+3. Las preguntas de noticias/superheroes podrán responder en modo mixto:
+- respuesta base de conocimiento +
+- enlace a seccion publica para detalle actual.
+4. Donaciones siempre redirigen al enlace oficial de Fundacion PROCLADE.
+
+---
+
+## Alcance de la seed inicial
+
+La seed incluye 11 intents:
+
+1. EQUIPO_PUCH_OVERVIEW
+2. UNIRSE_EQUIPO_PUCH
+3. PROYECTOS_INTERNACIONALES
+4. DONAR
+5. COLABORAR
+6. NOTICIAS
+7. SUPERHEROES
+8. RETOS_SOLIDARIOS
+9. BIBLIOTECAS_HUMANAS
+10. DELEGACIONES
+11. CONTACTO
+
+Y queda implementada en:
+
+- `backend/src/chatbot/seed/chatbot-seed.types.ts`
+- `backend/src/chatbot/seed/chatbot-seed.source.ts`
+
+---
+
+## Puntos pendientes para siguiente micro-bloque
+
+1. Crear modelos Prisma de chatbot.
+2. Crear script seed idempotente para persistir intents/phrases/knowledge.
+3. Definir estrategia para actualizar knowledge cuando cambie contenido admin.

--- a/docs/08-chatbot/08.3-hu39-prisma-model-and-seed.md
+++ b/docs/08-chatbot/08.3-hu39-prisma-model-and-seed.md
@@ -1,0 +1,87 @@
+# HU-39 - Microbloque 2: Modelo Prisma + migracion + seed idempotente
+
+## Objetivo del bloque
+
+Conectar la base de conocimiento definida en HU-39 con infraestructura real de datos:
+
+1. Modelos en `schema.prisma`.
+2. Migracion SQL versionada.
+3. Seed idempotente integrado en el orquestador.
+
+---
+
+## Cambios aplicados
+
+## 1) `schema.prisma`
+
+Se añadieron enums:
+
+- `ChatChannel`
+- `ChatMessageRole`
+- `ChatReplyType`
+
+Se añadieron modelos:
+
+- `ChatbotIntent`
+- `ChatbotIntentPhrase`
+- `KnowledgeItem`
+- `ChatSession`
+- `ChatMessage`
+- `UnresolvedQuestion`
+
+Se añadieron relaciones en `User`:
+
+- `chatSessions`
+- `resolvedUnresolved`
+
+## 2) Migracion SQL
+
+Ruta:
+
+- `backend/prisma/migrations/20260401133500_hu39_add_chatbot_core/migration.sql`
+
+Incluye:
+
+- Creacion de enums.
+- Creacion de tablas.
+- Indices para busqueda y operacion.
+- Foreign keys para integridad referencial.
+
+## 3) Seed chatbot
+
+Archivo nuevo:
+
+- `backend/prisma/seeds/chatbot-knowledge.seed.ts`
+
+Estrategia idempotente:
+
+- Intents: `upsert` por `code`.
+- Phrases: `upsert` por compuesto (`intentId`, `text`, `language`).
+- Knowledge: `upsert` por `questionCanonical`.
+
+## 4) Integracion en orquestador de seeds
+
+Archivo actualizado:
+
+- `backend/prisma/seeds/seed.ts`
+
+Se añadió la llamada:
+
+- `await seedChatbotKnowledge(prisma);`
+
+---
+
+## Validacion tecnica ejecutada
+
+Comandos:
+
+1. `yarn --cwd backend prisma:generate`
+2. `yarn --cwd backend build`
+
+Resultado:
+
+- Ambos comandos correctos.
+
+Nota:
+
+- No se ejecutó `prisma:seed` para evitar tocar datos existentes en este microbloque.

--- a/docs/08-chatbot/08.4-hu39-core-widget-and-api.md
+++ b/docs/08-chatbot/08.4-hu39-core-widget-and-api.md
@@ -1,0 +1,176 @@
+# 08.4 - HU39 Core chatbot (backend + widget inicial)
+
+## Objetivo
+
+Documentar la base técnica implementada en HU-39:
+
+- Backend de sesión + respuesta de chatbot.
+- Seed inicial de conocimiento.
+- Widget flotante en frontend para interacción real.
+
+---
+
+## Alcance implementado
+
+### Backend (NestJS + Prisma)
+
+1. Endpoints públicos:
+- `POST /chatbot/sessions`
+- `POST /chatbot/message`
+- `GET /chatbot/health`
+
+2. Persistencia:
+- `ChatSession`: sesión de conversación.
+- `ChatMessage`: mensajes usuario/bot.
+- `UnresolvedQuestion`: preguntas sin respuesta clara (fallback).
+
+3. Motor base de matching (HU-39):
+- Normalización de texto.
+- Ranking simple por similitud con:
+  - `questionCanonical`
+  - frases de intent
+  - tags
+- Resolución por umbrales:
+  - `DIRECT_ANSWER`
+  - `CLARIFICATION`
+  - `FALLBACK`
+
+4. Contrato de respuesta unificado:
+- Integración con `TransformInterceptor` y `GlobalExceptionFilter`.
+
+### Frontend (React + TypeScript)
+
+1. Feature nueva:
+- `frontend/src/features/chatbot/`
+
+2. Capas implementadas:
+- `types/`: contratos de datos (`ChatbotReplyData`, `ChatUiMessage`, etc.).
+- `api/`: cliente HTTP (`createChatbotSession`, `sendChatbotMessage`).
+- `utils/`: persistencia de `sessionId` en localStorage.
+- `hooks/`: estado y lógica (`useChatbot`).
+- `components/`: widget flotante y subcomponentes del launcher/mensajes.
+
+3. Integración UI:
+- Render global del widget en `PublicLayout`.
+- Comportamiento:
+  - abrir/cerrar panel,
+  - envío de mensajes,
+  - loading,
+  - render de CTA y sugerencias,
+  - navegación interna/externa desde CTA.
+
+---
+
+## Endpoints (resumen de contrato)
+
+### `POST /chatbot/sessions`
+
+Request:
+
+```json
+{
+  "sessionId": "uuid-opcional"
+}
+```
+
+Response (`data`):
+
+```json
+{
+  "sessionId": "uuid"
+}
+```
+
+### `POST /chatbot/message`
+
+Request:
+
+```json
+{
+  "sessionId": "uuid-opcional",
+  "message": "texto usuario",
+  "pageContext": "home|noticias|..."
+}
+```
+
+Response (`data`):
+
+```json
+{
+  "sessionId": "uuid",
+  "replyType": "DIRECT_ANSWER | CLARIFICATION | FALLBACK",
+  "answer": "texto respuesta",
+  "confidence": 0.0,
+  "detectedIntentCode": "INTENT_CODE | null",
+  "suggestions": ["..."],
+  "ctaLinks": [{ "label": "...", "to": "..." }]
+}
+```
+
+### `GET /chatbot/health`
+
+Response (`data`):
+
+```json
+{
+  "status": "ok",
+  "totalKnowledgeItems": 0,
+  "thresholds": {
+    "directAnswer": 0.72,
+    "clarification": 0.45
+  }
+}
+```
+
+---
+
+## Archivos principales
+
+### Backend
+
+- `backend/src/chatbot/chatbot.module.ts`
+- `backend/src/chatbot/chatbot.controller.ts`
+- `backend/src/chatbot/chatbot-orchestrator.service.ts`
+- `backend/src/chatbot/knowledge-base.service.ts`
+- `backend/src/chatbot/chatbot-session.service.ts`
+- `backend/src/chatbot/unresolved-question.service.ts`
+
+### Frontend
+
+- `frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx`
+- `frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css`
+- `frontend/src/features/chatbot/hooks/useChatbot.ts`
+- `frontend/src/features/chatbot/api/chatbot.api.ts`
+- `frontend/src/router/layouts/PublicLayout.tsx`
+
+---
+
+## Validación técnica realizada
+
+Comandos ejecutados:
+
+```bash
+yarn --cwd backend build
+yarn --cwd frontend eslint "src/features/chatbot/**/*.ts" "src/features/chatbot/**/*.tsx" src/router/layouts/PublicLayout.tsx
+yarn --cwd frontend build
+```
+
+Resultado:
+- build backend OK.
+- lint frontend del feature chatbot OK.
+- build frontend OK.
+
+Nota de entorno:
+- El e2e de chatbot (`backend/test/chatbot/chatbot.e2e-spec.ts`) requiere base de datos accesible (`db`) para ejecutarse correctamente.
+
+---
+
+## Criterio de cierre HU-39
+
+HU-39 queda cerrada cuando:
+
+1. El usuario puede abrir el widget desde cualquier página pública.
+2. Puede enviar mensaje y recibir respuesta del backend.
+3. Se crea/reutiliza sesión persistente en localStorage.
+4. Las preguntas sin match quedan registradas en `UnresolvedQuestion`.
+5. El backend mantiene contrato unificado `{ success, message, data }`.

--- a/frontend/src/features/chatbot/api/chatbot.api.ts
+++ b/frontend/src/features/chatbot/api/chatbot.api.ts
@@ -1,0 +1,31 @@
+import api from '../../../services/http/axios.instance';
+import type { ApiResponse } from '../../../types/api';
+import type {
+  ChatbotReplyData,
+  ChatbotSessionData,
+  SendChatbotMessagePayload,
+} from '../types/chatbot.types';
+
+export async function createChatbotSession(
+  sessionId?: string,
+): Promise<ApiResponse<ChatbotSessionData>> {
+  const response = await api.post<ApiResponse<ChatbotSessionData>>(
+    '/chatbot/sessions',
+    {
+      sessionId,
+    },
+  );
+
+  return response.data;
+}
+
+export async function sendChatbotMessage(
+  payload: SendChatbotMessagePayload,
+): Promise<ApiResponse<ChatbotReplyData>> {
+  const response = await api.post<ApiResponse<ChatbotReplyData>>(
+    '/chatbot/message',
+    payload,
+  );
+
+  return response.data;
+}

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
@@ -20,16 +20,18 @@
   background: var(--brand-white);
   display: flex;
   flex-direction: column;
-  opacity: 0;
-  transform: translateY(0.5rem) scale(0.98);
-  pointer-events: none;
-  transition: opacity 160ms ease, transform 180ms ease;
+  animation: chatbotPanelIn 180ms ease-out;
 }
 
-.chatbot-widget--open .chatbot-panel {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-  pointer-events: auto;
+@keyframes chatbotPanelIn {
+  from {
+    opacity: 0;
+    transform: translateY(0.45rem) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .chatbot-panel__header {

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
@@ -1,0 +1,289 @@
+.chatbot-widget {
+  position: fixed;
+  right: clamp(0.8rem, 2.2vw, 1.6rem);
+  bottom: clamp(0.9rem, 2.4vw, 1.5rem);
+  z-index: 1070;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.65rem;
+}
+
+.chatbot-panel {
+  width: min(24.5rem, calc(100vw - 1.2rem));
+  height: min(34rem, calc(100vh - 1.6rem));
+  max-height: 76vh;
+  border-radius: 1rem;
+  border: 1px solid rgba(13, 59, 115, 0.16);
+  box-shadow: 0 18px 40px rgba(17, 24, 39, 0.24);
+  overflow: hidden;
+  background: var(--brand-white);
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  transform: translateY(0.5rem) scale(0.98);
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 180ms ease;
+}
+
+.chatbot-widget--open .chatbot-panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.chatbot-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 0.82rem 0.95rem;
+  border-bottom: 1px solid rgba(13, 59, 115, 0.08);
+  background: linear-gradient(
+    135deg,
+    rgba(107, 170, 117, 0.94),
+    rgba(13, 59, 115, 0.95)
+  );
+  color: var(--brand-white);
+}
+
+.chatbot-panel__eyebrow {
+  margin: 0 0 0.1rem;
+  opacity: 0.9;
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.chatbot-panel__title {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.1;
+}
+
+.chatbot-panel__close {
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: var(--brand-white);
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 0.6rem;
+}
+
+.chatbot-panel__close:hover,
+.chatbot-panel__close:focus {
+  color: var(--brand-white);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.chatbot-panel__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  background: linear-gradient(
+    180deg,
+    rgba(107, 170, 117, 0.07) 0%,
+    rgba(255, 255, 255, 0.95) 45%
+  );
+}
+
+.chatbot-message {
+  max-width: 92%;
+  border-radius: 0.9rem;
+  padding: 0.64rem 0.72rem;
+  font-size: 0.92rem;
+}
+
+.chatbot-message--bot {
+  align-self: flex-start;
+  background: #f1f4f8;
+  border: 1px solid rgba(13, 59, 115, 0.1);
+  color: var(--brand-dark);
+}
+
+.chatbot-message--user {
+  align-self: flex-end;
+  background: linear-gradient(135deg, #2f7f6b, #3b8a72);
+  color: var(--brand-white);
+}
+
+.chatbot-message__text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.chatbot-message__cta-group,
+.chatbot-message__suggestions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.38rem;
+}
+
+.chatbot-message__cta,
+.chatbot-message__suggestion {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.56rem;
+}
+
+.chatbot-message__cta {
+  color: var(--brand-secondary);
+  border: 1px solid rgba(13, 59, 115, 0.26);
+  background: rgba(13, 59, 115, 0.08);
+}
+
+.chatbot-message__cta:hover,
+.chatbot-message__cta:focus {
+  color: var(--brand-secondary);
+  border-color: rgba(13, 59, 115, 0.42);
+  background: rgba(13, 59, 115, 0.14);
+}
+
+.chatbot-message__suggestion {
+  color: #1f5f4a;
+  border: 1px solid rgba(58, 128, 72, 0.26);
+  background: rgba(107, 170, 117, 0.15);
+}
+
+.chatbot-message__suggestion:hover,
+.chatbot-message__suggestion:focus {
+  color: #1f5f4a;
+  border-color: rgba(58, 128, 72, 0.45);
+  background: rgba(107, 170, 117, 0.24);
+}
+
+.chatbot-message--typing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  width: max-content;
+}
+
+.chatbot-typing-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: var(--brand-secondary);
+  opacity: 0.45;
+  animation: chatbotTyping 950ms infinite ease-in-out;
+}
+
+.chatbot-typing-dot:nth-child(2) {
+  animation-delay: 110ms;
+}
+
+.chatbot-typing-dot:nth-child(3) {
+  animation-delay: 220ms;
+}
+
+@keyframes chatbotTyping {
+  0%,
+  60%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 0.95;
+    transform: translateY(-0.16rem);
+  }
+}
+
+.chatbot-panel__error {
+  margin: 0;
+  padding: 0.5rem 0.85rem 0;
+  color: #9f1239;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.chatbot-panel__composer {
+  border-top: 1px solid rgba(13, 59, 115, 0.08);
+  padding: 0.72rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: var(--brand-white);
+}
+
+.chatbot-panel__input {
+  width: 100%;
+  border-radius: 0.78rem;
+  border: 1px solid rgba(13, 59, 115, 0.2);
+  min-height: 2.75rem;
+  max-height: 7.6rem;
+  resize: vertical;
+  padding: 0.62rem 0.72rem;
+  font: inherit;
+  color: var(--brand-dark);
+}
+
+.chatbot-panel__input:focus {
+  outline: 2px solid rgba(107, 170, 117, 0.42);
+  border-color: rgba(58, 128, 72, 0.6);
+}
+
+.chatbot-panel__send {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+}
+
+.chatbot-launcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.52rem;
+  border-radius: 999px;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid rgba(13, 59, 115, 0.12);
+  background: linear-gradient(135deg, #4d9860, #2f7f6b);
+  color: var(--brand-white);
+  font-weight: 800;
+  font-size: 0.9rem;
+  box-shadow: 0 12px 22px rgba(24, 87, 58, 0.34);
+}
+
+.chatbot-launcher:hover,
+.chatbot-launcher:focus {
+  color: var(--brand-white);
+  background: linear-gradient(135deg, #438a55, #286d5b);
+}
+
+.chatbot-launcher__icon {
+  width: 1.48rem;
+  height: 1.48rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.chatbot-launcher__text {
+  line-height: 1;
+}
+
+@media (max-width: 575.98px) {
+  .chatbot-widget {
+    right: 0.5rem;
+    bottom: 0.62rem;
+  }
+
+  .chatbot-panel {
+    width: calc(100vw - 1rem);
+    height: min(33rem, calc(100vh - 1.2rem));
+    max-height: 80vh;
+  }
+
+  .chatbot-launcher {
+    padding: 0.56rem 0.78rem;
+  }
+
+  .chatbot-launcher__text {
+    font-size: 0.84rem;
+  }
+}

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
@@ -77,79 +77,81 @@ export function ChatbotWidget() {
 
   return (
     <aside className={`chatbot-widget ${isOpen ? 'chatbot-widget--open' : ''}`}>
-      <div id="chatbot-panel" className="chatbot-panel" aria-hidden={!isOpen}>
-        <header className="chatbot-panel__header">
-          <div>
-            <p className="chatbot-panel__eyebrow">Asistente virtual</p>
-            <h2 className="chatbot-panel__title">Equipo PUCH</h2>
-          </div>
-          <button
-            type="button"
-            className="chatbot-panel__close btn btn-sm"
-            onClick={handleToggle}
-            aria-label="Cerrar asistente"
-          >
-            <i className="bi bi-x-lg" />
-          </button>
-        </header>
-
-        <div className="chatbot-panel__messages" ref={messagesContainerRef}>
-          {messages.map((message) => (
-            <ChatbotMessageItem
-              key={message.id}
-              message={message}
-              onSuggestionClick={handleSuggestionClick}
-              onCtaClick={handleCtaClick}
-            />
-          ))}
-          {isSending && (
-            <div className="chatbot-message chatbot-message--bot chatbot-message--typing">
-              <span className="chatbot-typing-dot" />
-              <span className="chatbot-typing-dot" />
-              <span className="chatbot-typing-dot" />
+      {isOpen && (
+        <div id="chatbot-panel" className="chatbot-panel">
+          <header className="chatbot-panel__header">
+            <div>
+              <p className="chatbot-panel__eyebrow">Asistente virtual</p>
+              <h2 className="chatbot-panel__title">Equipo PUCH</h2>
             </div>
+            <button
+              type="button"
+              className="chatbot-panel__close btn btn-sm"
+              onClick={handleToggle}
+              aria-label="Cerrar asistente"
+            >
+              <i className="bi bi-x-lg" />
+            </button>
+          </header>
+
+          <div className="chatbot-panel__messages" ref={messagesContainerRef}>
+            {messages.map((message) => (
+              <ChatbotMessageItem
+                key={message.id}
+                message={message}
+                onSuggestionClick={handleSuggestionClick}
+                onCtaClick={handleCtaClick}
+              />
+            ))}
+            {isSending && (
+              <div className="chatbot-message chatbot-message--bot chatbot-message--typing">
+                <span className="chatbot-typing-dot" />
+                <span className="chatbot-typing-dot" />
+                <span className="chatbot-typing-dot" />
+              </div>
+            )}
+          </div>
+
+          {errorMessage && (
+            <p className="chatbot-panel__error" role="status" aria-live="polite">
+              {errorMessage}
+            </p>
           )}
-        </div>
 
-        {errorMessage && (
-          <p className="chatbot-panel__error" role="status" aria-live="polite">
-            {errorMessage}
-          </p>
-        )}
+          <form className="chatbot-panel__composer" onSubmit={handleSubmit}>
+            <label className="visually-hidden" htmlFor="chatbot-input">
+              Escribe tu mensaje
+            </label>
+            <textarea
+              id="chatbot-input"
+              className="chatbot-panel__input"
+              value={draftMessage}
+              onChange={(event) => setDraftMessage(event.target.value)}
+              placeholder="Escribe tu pregunta..."
+              rows={1}
+              maxLength={1200}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault();
+                  const formNode = event.currentTarget.form;
 
-        <form className="chatbot-panel__composer" onSubmit={handleSubmit}>
-          <label className="visually-hidden" htmlFor="chatbot-input">
-            Escribe tu mensaje
-          </label>
-          <textarea
-            id="chatbot-input"
-            className="chatbot-panel__input"
-            value={draftMessage}
-            onChange={(event) => setDraftMessage(event.target.value)}
-            placeholder="Escribe tu pregunta..."
-            rows={1}
-            maxLength={1200}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault();
-                const formNode = event.currentTarget.form;
-
-                if (formNode) {
-                  formNode.requestSubmit();
+                  if (formNode) {
+                    formNode.requestSubmit();
+                  }
                 }
-              }
-            }}
-          />
-          <button
-            type="submit"
-            className="chatbot-panel__send btn btn-brand-gradient"
-            disabled={isSending || draftMessage.trim().length === 0}
-          >
-            <i className="bi bi-send-fill" aria-hidden="true" />
-            <span>Enviar</span>
-          </button>
-        </form>
-      </div>
+              }}
+            />
+            <button
+              type="submit"
+              className="chatbot-panel__send btn btn-brand-gradient"
+              disabled={isSending || draftMessage.trim().length === 0}
+            >
+              <i className="bi bi-send-fill" aria-hidden="true" />
+              <span>Enviar</span>
+            </button>
+          </form>
+        </div>
+      )}
 
       <ChatbotLauncherButton isOpen={isOpen} onClick={handleToggle} />
     </aside>

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
@@ -1,0 +1,170 @@
+import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useChatbot } from '../../hooks/useChatbot';
+import type { ChatbotCtaLink } from '../../types/chatbot.types';
+import { ChatbotLauncherButton } from './parts/ChatbotLauncherButton';
+import { ChatbotMessageItem } from './parts/ChatbotMessageItem';
+import './ChatbotWidget.css';
+
+export function ChatbotWidget() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftMessage, setDraftMessage] = useState('');
+  const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+  const {
+    messages,
+    isSending,
+    errorMessage,
+    sendMessage,
+  } = useChatbot();
+
+  const pageContext = useMemo(
+    () => buildPageContextFromPath(location.pathname),
+    [location.pathname],
+  );
+
+  useEffect(() => {
+    const node = messagesContainerRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    node.scrollTop = node.scrollHeight;
+  }, [messages, isOpen]);
+
+  const handleToggle = () => {
+    setIsOpen((previous) => !previous);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextMessage = draftMessage.trim();
+
+    if (!nextMessage || isSending) {
+      return;
+    }
+
+    setDraftMessage('');
+    void sendMessage(nextMessage, pageContext);
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    if (isSending) {
+      return;
+    }
+
+    setDraftMessage('');
+    void sendMessage(suggestion, pageContext);
+  };
+
+  const handleCtaClick = (link: ChatbotCtaLink) => {
+    if (isExternalLink(link.to)) {
+      if (link.to.startsWith('http')) {
+        window.open(link.to, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
+      window.location.href = link.to;
+      return;
+    }
+
+    navigate(link.to);
+    setIsOpen(false);
+  };
+
+  return (
+    <aside className={`chatbot-widget ${isOpen ? 'chatbot-widget--open' : ''}`}>
+      <div id="chatbot-panel" className="chatbot-panel" aria-hidden={!isOpen}>
+        <header className="chatbot-panel__header">
+          <div>
+            <p className="chatbot-panel__eyebrow">Asistente virtual</p>
+            <h2 className="chatbot-panel__title">Equipo PUCH</h2>
+          </div>
+          <button
+            type="button"
+            className="chatbot-panel__close btn btn-sm"
+            onClick={handleToggle}
+            aria-label="Cerrar asistente"
+          >
+            <i className="bi bi-x-lg" />
+          </button>
+        </header>
+
+        <div className="chatbot-panel__messages" ref={messagesContainerRef}>
+          {messages.map((message) => (
+            <ChatbotMessageItem
+              key={message.id}
+              message={message}
+              onSuggestionClick={handleSuggestionClick}
+              onCtaClick={handleCtaClick}
+            />
+          ))}
+          {isSending && (
+            <div className="chatbot-message chatbot-message--bot chatbot-message--typing">
+              <span className="chatbot-typing-dot" />
+              <span className="chatbot-typing-dot" />
+              <span className="chatbot-typing-dot" />
+            </div>
+          )}
+        </div>
+
+        {errorMessage && (
+          <p className="chatbot-panel__error" role="status" aria-live="polite">
+            {errorMessage}
+          </p>
+        )}
+
+        <form className="chatbot-panel__composer" onSubmit={handleSubmit}>
+          <label className="visually-hidden" htmlFor="chatbot-input">
+            Escribe tu mensaje
+          </label>
+          <textarea
+            id="chatbot-input"
+            className="chatbot-panel__input"
+            value={draftMessage}
+            onChange={(event) => setDraftMessage(event.target.value)}
+            placeholder="Escribe tu pregunta..."
+            rows={1}
+            maxLength={1200}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                const formNode = event.currentTarget.form;
+
+                if (formNode) {
+                  formNode.requestSubmit();
+                }
+              }
+            }}
+          />
+          <button
+            type="submit"
+            className="chatbot-panel__send btn btn-brand-gradient"
+            disabled={isSending || draftMessage.trim().length === 0}
+          >
+            <i className="bi bi-send-fill" aria-hidden="true" />
+            <span>Enviar</span>
+          </button>
+        </form>
+      </div>
+
+      <ChatbotLauncherButton isOpen={isOpen} onClick={handleToggle} />
+    </aside>
+  );
+}
+
+function buildPageContextFromPath(pathname: string) {
+  return pathname.replace(/\//g, ' ').trim() || 'home';
+}
+
+function isExternalLink(url: string) {
+  return (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('mailto:') ||
+    url.startsWith('tel:')
+  );
+}

--- a/frontend/src/features/chatbot/components/ChatbotWidget/parts/ChatbotLauncherButton.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/parts/ChatbotLauncherButton.tsx
@@ -1,0 +1,27 @@
+type ChatbotLauncherButtonProps = {
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+export function ChatbotLauncherButton({
+  isOpen,
+  onClick,
+}: ChatbotLauncherButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`chatbot-launcher ${isOpen ? 'chatbot-launcher--open' : ''}`}
+      onClick={onClick}
+      aria-expanded={isOpen}
+      aria-controls="chatbot-panel"
+      aria-label={isOpen ? 'Cerrar asistente PUCH' : 'Abrir asistente PUCH'}
+    >
+      <span className="chatbot-launcher__icon" aria-hidden="true">
+        <i className={`bi ${isOpen ? 'bi-x-lg' : 'bi-chat-dots-fill'}`} />
+      </span>
+      <span className="chatbot-launcher__text">
+        {isOpen ? 'Cerrar chat' : 'Asistente PUCH'}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/features/chatbot/components/ChatbotWidget/parts/ChatbotMessageItem.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/parts/ChatbotMessageItem.tsx
@@ -1,0 +1,57 @@
+import type { ChatbotCtaLink, ChatUiMessage } from '../../../types/chatbot.types';
+
+type ChatbotMessageItemProps = {
+  message: ChatUiMessage;
+  onSuggestionClick: (suggestion: string) => void;
+  onCtaClick: (link: ChatbotCtaLink) => void;
+};
+
+export function ChatbotMessageItem({
+  message,
+  onSuggestionClick,
+  onCtaClick,
+}: ChatbotMessageItemProps) {
+  const isBot = message.role === 'bot';
+
+  return (
+    <article
+      className={`chatbot-message ${
+        isBot ? 'chatbot-message--bot' : 'chatbot-message--user'
+      }`}
+    >
+      <p className="chatbot-message__text">{message.text}</p>
+
+      {isBot && Array.isArray(message.ctaLinks) && message.ctaLinks.length > 0 && (
+        <div className="chatbot-message__cta-group">
+          {message.ctaLinks.map((link) => (
+            <button
+              key={`${message.id}-${link.to}-${link.label}`}
+              type="button"
+              className="chatbot-message__cta btn btn-sm"
+              onClick={() => onCtaClick(link)}
+            >
+              {link.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isBot &&
+        Array.isArray(message.suggestions) &&
+        message.suggestions.length > 0 && (
+          <div className="chatbot-message__suggestions">
+            {message.suggestions.slice(0, 3).map((suggestion) => (
+              <button
+                key={`${message.id}-${suggestion}`}
+                type="button"
+                className="chatbot-message__suggestion btn btn-sm"
+                onClick={() => onSuggestionClick(suggestion)}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        )}
+    </article>
+  );
+}

--- a/frontend/src/features/chatbot/hooks/useChatbot.ts
+++ b/frontend/src/features/chatbot/hooks/useChatbot.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  createChatbotSession,
+  sendChatbotMessage,
+} from '../api/chatbot.api';
+import type { ChatUiMessage } from '../types/chatbot.types';
+import {
+  clearChatbotSessionId,
+  getChatbotSessionId,
+  saveChatbotSessionId,
+} from '../utils/chatbot-session.storage';
+
+const DEFAULT_ERROR_MESSAGE =
+  'No he podido conectar con el asistente ahora mismo. Inténtalo de nuevo en unos segundos.';
+
+const CHATBOT_WELCOME_MESSAGE: ChatUiMessage = {
+  id: 'chatbot-welcome',
+  role: 'bot',
+  text: 'Hola, soy el asistente de Equipo PUCH. Te ayudo con donaciones, noticias, superhéroes y cómo colaborar.',
+  createdAt: new Date().toISOString(),
+  suggestions: [
+    '¿Cómo puedo donar?',
+    '¿Qué es Equipo PUCH?',
+    'Enséñame las últimas noticias',
+  ],
+};
+
+type UseChatbotResult = {
+  messages: ChatUiMessage[];
+  isSending: boolean;
+  errorMessage: string | null;
+  sendMessage: (message: string, pageContext?: string) => Promise<void>;
+};
+
+export function useChatbot(): UseChatbotResult {
+  const [sessionId, setSessionId] = useState<string | null>(() =>
+    getChatbotSessionId(),
+  );
+  const [messages, setMessages] = useState<ChatUiMessage[]>([
+    CHATBOT_WELCOME_MESSAGE,
+  ]);
+  const [isSending, setIsSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const ensureSession = useCallback(async () => {
+    const response = await createChatbotSession(sessionId ?? undefined);
+
+    if (!response.success || !response.data?.sessionId) {
+      throw new Error(response.message || DEFAULT_ERROR_MESSAGE);
+    }
+
+    const nextSessionId = response.data.sessionId;
+
+    if (nextSessionId !== sessionId) {
+      setSessionId(nextSessionId);
+      saveChatbotSessionId(nextSessionId);
+    }
+
+    return nextSessionId;
+  }, [sessionId]);
+
+  useEffect(() => {
+    void ensureSession().catch(() => {
+      clearChatbotSessionId();
+      setSessionId(null);
+    });
+  }, [ensureSession]);
+
+  const sendMessage = useCallback(
+    async (rawMessage: string, pageContext?: string) => {
+      const trimmedMessage = rawMessage.trim();
+
+      if (!trimmedMessage || isSending) {
+        return;
+      }
+
+      setErrorMessage(null);
+      setMessages((previous) => [
+        ...previous,
+        buildUiMessage({
+          role: 'user',
+          text: trimmedMessage,
+        }),
+      ]);
+      setIsSending(true);
+
+      try {
+        const activeSessionId = await ensureSession();
+        const response = await sendChatbotMessage({
+          message: trimmedMessage,
+          sessionId: activeSessionId,
+          pageContext,
+        });
+
+        if (!response.success || !response.data) {
+          throw new Error(response.message || DEFAULT_ERROR_MESSAGE);
+        }
+
+        const reply = response.data;
+
+        if (reply.sessionId && reply.sessionId !== sessionId) {
+          setSessionId(reply.sessionId);
+          saveChatbotSessionId(reply.sessionId);
+        }
+
+        setMessages((previous) => [
+          ...previous,
+          buildUiMessage({
+            role: 'bot',
+            text: reply.answer,
+            replyType: reply.replyType,
+            ctaLinks: reply.ctaLinks,
+            suggestions: reply.suggestions,
+          }),
+        ]);
+      } catch {
+        setErrorMessage(DEFAULT_ERROR_MESSAGE);
+        clearChatbotSessionId();
+        setSessionId(null);
+        setMessages((previous) => [
+          ...previous,
+          buildUiMessage({
+            role: 'bot',
+            text: DEFAULT_ERROR_MESSAGE,
+            replyType: 'FALLBACK',
+          }),
+        ]);
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [ensureSession, isSending, sessionId],
+  );
+
+  return {
+    messages,
+    isSending,
+    errorMessage,
+    sendMessage,
+  };
+}
+
+function buildUiMessage(payload: Omit<ChatUiMessage, 'id' | 'createdAt'>): ChatUiMessage {
+  return {
+    id: buildMessageId(),
+    createdAt: new Date().toISOString(),
+    ...payload,
+  };
+}
+
+function buildMessageId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `msg-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/frontend/src/features/chatbot/types/chatbot.types.ts
+++ b/frontend/src/features/chatbot/types/chatbot.types.ts
@@ -1,0 +1,41 @@
+export type ChatbotReplyType =
+  | 'DIRECT_ANSWER'
+  | 'CLARIFICATION'
+  | 'FALLBACK';
+
+export type ChatbotCtaLink = {
+  label: string;
+  to: string;
+};
+
+export type ChatbotSessionData = {
+  sessionId: string;
+};
+
+export type ChatbotReplyData = {
+  sessionId: string;
+  replyType: ChatbotReplyType;
+  answer: string;
+  confidence: number;
+  detectedIntentCode: string | null;
+  suggestions: string[];
+  ctaLinks: ChatbotCtaLink[];
+};
+
+export type SendChatbotMessagePayload = {
+  message: string;
+  sessionId?: string;
+  pageContext?: string;
+};
+
+export type ChatRole = 'user' | 'bot';
+
+export type ChatUiMessage = {
+  id: string;
+  role: ChatRole;
+  text: string;
+  createdAt: string;
+  replyType?: ChatbotReplyType;
+  ctaLinks?: ChatbotCtaLink[];
+  suggestions?: string[];
+};

--- a/frontend/src/features/chatbot/utils/chatbot-session.storage.ts
+++ b/frontend/src/features/chatbot/utils/chatbot-session.storage.ts
@@ -1,0 +1,26 @@
+const CHATBOT_SESSION_STORAGE_KEY = 'chatbotSessionId';
+const isBrowser = typeof window !== 'undefined';
+
+export function getChatbotSessionId(): string | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  return localStorage.getItem(CHATBOT_SESSION_STORAGE_KEY);
+}
+
+export function saveChatbotSessionId(sessionId: string): void {
+  if (!isBrowser) {
+    return;
+  }
+
+  localStorage.setItem(CHATBOT_SESSION_STORAGE_KEY, sessionId);
+}
+
+export function clearChatbotSessionId(): void {
+  if (!isBrowser) {
+    return;
+  }
+
+  localStorage.removeItem(CHATBOT_SESSION_STORAGE_KEY);
+}

--- a/frontend/src/router/layouts/PublicLayout.tsx
+++ b/frontend/src/router/layouts/PublicLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { Header } from '../../components/layout/Header/Header';
 import { Footer } from '../../components/layout/Footer/Footer';
+import { ChatbotWidget } from '../../features/chatbot/components/ChatbotWidget/ChatbotWidget';
 import './PublicLayout.css';
 
 export function PublicLayout() {
@@ -11,6 +12,7 @@ export function PublicLayout() {
         <Outlet />
       </main>
       <Footer />
+      <ChatbotWidget />
     </div>
   );
 }


### PR DESCRIPTION
## Resumen
- Se añade la base de datos del chatbot en Prisma (modelos, enums e índices) con migración y seed idempotente de conocimiento.
- Se implementa el módulo backend `chatbot` con endpoints públicos:
  - `POST /chatbot/sessions`
  - `POST /chatbot/message`
  - `GET /chatbot/health`
- Se implementa el flujo base de orquestación (normalización, ranking simple, umbrales de `DIRECT_ANSWER | CLARIFICATION | FALLBACK`) y persistencia de mensajes/sesiones.
- Se añade registro de preguntas no resueltas en `UnresolvedQuestion` para iteración posterior del conocimiento.
- Se implementa el widget flotante en frontend (launcher + panel + mensajes + sugerencias/CTA + envío) integrado en `PublicLayout`.
- Se añade persistencia de `sessionId` en localStorage para continuidad de conversación en cliente.
- Se añade test e2e base del chatbot y documentación técnica de HU-39.

## Validación
- `yarn --cwd backend build` ✅
- `yarn --cwd frontend eslint "src/features/chatbot/**/*.ts" "src/features/chatbot/**/*.tsx" src/router/layouts/PublicLayout.tsx` ✅
- `yarn --cwd frontend build` ✅
- `yarn --cwd backend test:e2e -- test/chatbot/chatbot.e2e-spec.ts` ⚠️ no ejecutable en este entorno por falta de conexión a BD (`db`).

## Notas
- Se mantiene `tmp/` fuera de versionado (sin incluir en la PR).
- Esta PR cubre HU-39 (base técnica + widget inicial).
