### PR TITLE
HU-46 — Nginx: Bloqueo de acceso a archivos y rutas sensibles

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,36 @@
 server {
   listen 80;
 
+  # Excepción: mantener disponible .well-known (ACME/challenges u otros usos controlados)
+  location ^~ /.well-known/ {
+    proxy_pass http://frontend:5173;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+  }
+
+  # Bloqueo explícito de archivos y rutas sensibles
+  location = /.env {
+    return 404;
+  }
+
+  location ~* ^/\.git {
+    return 404;
+  }
+
+  location ~* ^/\.ht {
+    return 404;
+  }
+
+  # Bloquear otros archivos ocultos (excepto .well-known por regla superior)
+  location ~ /\.(?!well-known\/).* {
+    return 404;
+  }
+
+  # Bloquear copias de seguridad y archivos temporales comunes
+  location ~* (\.bak$|\.old$|~$) {
+    return 404;
+  }
+
   # FRONTEND (Vite)
   location / {
     proxy_pass http://frontend:5173;


### PR DESCRIPTION
## 📌 Resumen

Implementa la HU-46 añadiendo reglas en Nginx para bloquear acceso público a archivos y rutas sensibles.

### Cambios
- Bloqueo explícito de `/.env`.
- Bloqueo explícito de rutas `/.git*`.
- Bloqueo explícito de rutas `/.ht*`.
- Bloqueo general de archivos ocultos (`/.*`) con excepción de `/.well-known/`.
- Bloqueo de extensiones/formatos temporales: `*.bak`, `*.old`, `*~`.
- Excepción controlada para `/.well-known/`.

## 🧪 Pruebas realizadas

- `docker compose up -d db redis backend frontend nginx`
- `docker compose exec nginx nginx -t` -> syntax ok
- `curl -I http://localhost/.env` -> 404
- `curl -I http://localhost/.git/config` -> 404
- `curl -I http://localhost/.htaccess` -> 404
- `curl -I http://localhost/backup.old` -> 404
- `curl -I http://localhost/.well-known/test` -> 200
- `curl -I http://localhost/` -> 200

## ✅ Impacto

No introduce cambios en backend/frontend de negocio. Solo hardening de capa Nginx.
