### PR TITLE
HU-30 — Perfil de usuario y cambio de contraseña

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,10 +1,18 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { GoogleSignInDto } from './dto/google-sign-in.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { AuthService } from './auth.service';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { JwtAuthGuard } from './jwt_strategy/jwt-auth.guard';
+
+type AuthenticatedRequest = {
+  user: {
+    id: number;
+  };
+};
 
 @Controller('auth')
 export class AuthController {
@@ -33,5 +41,14 @@ export class AuthController {
   @Post('reset-password')
   resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
     return this.authService.resetPassword(resetPasswordDto);
+  }
+
+  @Patch('change-password')
+  @UseGuards(JwtAuthGuard)
+  changePassword(
+    @Req() request: AuthenticatedRequest,
+    @Body() changePasswordDto: ChangePasswordDto,
+  ) {
+    return this.authService.changePassword(request.user.id, changePasswordDto);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -21,6 +21,7 @@ import { GoogleAuthService } from './google/google-auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 
 type UserWithRoles = Prisma.UserGetPayload<{
   include: {
@@ -297,5 +298,66 @@ export class AuthService {
 
     this.logger.log(`Contraseña restablecida para usuario ID: ${user.id}`);
     return { message: 'Contraseña cambiada con éxito' };
+  }
+
+  async changePassword(userId: number, changePasswordDto: ChangePasswordDto) {
+    const user = await this.prisma.user.findFirst({
+      where: {
+        id: userId,
+        deletedAt: null,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    if (user.google) {
+      throw new BadRequestException(
+        'Las cuentas de Google deben cambiar la contraseña desde su proveedor.',
+      );
+    }
+
+    if (
+      changePasswordDto.newPassword !== changePasswordDto.confirmNewPassword
+    ) {
+      throw new BadRequestException(
+        'La confirmación de contraseña no coincide con la nueva contraseña',
+      );
+    }
+
+    const isCurrentPasswordValid = await bcrypt.compare(
+      changePasswordDto.currentPassword,
+      user.passwordHash,
+    );
+
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException('La contraseña actual no es correcta');
+    }
+
+    const isSameAsCurrent = await bcrypt.compare(
+      changePasswordDto.newPassword,
+      user.passwordHash,
+    );
+
+    if (isSameAsCurrent) {
+      throw new BadRequestException(
+        'La nueva contraseña debe ser diferente a la actual',
+      );
+    }
+
+    const newPasswordHash = await bcrypt.hash(changePasswordDto.newPassword, 10);
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        passwordHash: newPasswordHash,
+        resetPasswordTokenHash: null,
+        resetPasswordExpiresAt: null,
+      },
+    });
+
+    this.logger.log(`Contraseña actualizada para usuario ID: ${user.id}`);
+    return { message: 'Contraseña actualizada correctamente' };
   }
 }

--- a/backend/src/auth/dto/change-password.dto.ts
+++ b/backend/src/auth/dto/change-password.dto.ts
@@ -7,8 +7,8 @@ export class ChangePasswordDto {
 
   @IsString()
   @IsNotEmpty({ message: 'La nueva contraseña es obligatoria' })
-  @MinLength(8, {
-    message: 'La nueva contraseña debe tener al menos 8 caracteres',
+  @MinLength(6, {
+    message: 'La nueva contraseña debe tener al menos 6 caracteres',
   })
   newPassword: string;
 

--- a/backend/src/auth/dto/change-password.dto.ts
+++ b/backend/src/auth/dto/change-password.dto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsString()
+  @IsNotEmpty({ message: 'La contraseña actual es obligatoria' })
+  currentPassword: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'La nueva contraseña es obligatoria' })
+  @MinLength(8, {
+    message: 'La nueva contraseña debe tener al menos 8 caracteres',
+  })
+  newPassword: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'La confirmación de contraseña es obligatoria' })
+  confirmNewPassword: string;
+}

--- a/backend/src/users/dto/update-profile.dto.ts
+++ b/backend/src/users/dto/update-profile.dto.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsString()
+  @IsNotEmpty({ message: 'El nombre es obligatorio' })
+  @MaxLength(80, {
+    message: 'El nombre no puede superar los 80 caracteres',
+  })
+  name: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'Los apellidos son obligatorios' })
+  @MaxLength(120, {
+    message: 'Los apellidos no pueden superar los 120 caracteres',
+  })
+  surname: string;
+}

--- a/backend/src/users/users-profile.controller.ts
+++ b/backend/src/users/users-profile.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt_strategy/jwt-auth.guard';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UsersService } from './users.service';
+
+type RequestWithUser = {
+  user: {
+    id: number;
+  };
+};
+
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+export class UsersProfileController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  findMyProfile(@Req() request: RequestWithUser) {
+    return this.usersService.findProfileById(request.user.id);
+  }
+
+  @Patch('me')
+  updateMyProfile(
+    @Req() request: RequestWithUser,
+    @Body() updateProfileDto: UpdateProfileDto,
+  ) {
+    return this.usersService.updateProfileById(request.user.id, updateProfileDto);
+  }
+}

--- a/backend/src/users/users-profile.controller.ts
+++ b/backend/src/users/users-profile.controller.ts
@@ -9,17 +9,17 @@ type RequestWithUser = {
   };
 };
 
-@Controller('users')
+@Controller('users/me')
 @UseGuards(JwtAuthGuard)
 export class UsersProfileController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Get('me')
+  @Get()
   findMyProfile(@Req() request: RequestWithUser) {
     return this.usersService.findProfileById(request.user.id);
   }
 
-  @Patch('me')
+  @Patch()
   updateMyProfile(
     @Req() request: RequestWithUser,
     @Body() updateProfileDto: UpdateProfileDto,

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,9 +3,10 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
+import { UsersProfileController } from './users-profile.controller';
 @Module({
   imports: [PrismaModule, forwardRef(() => AuthModule)],
-  controllers: [UsersController],
+  controllers: [UsersController, UsersProfileController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -6,7 +6,7 @@ import { AuthModule } from '../auth/auth.module';
 import { UsersProfileController } from './users-profile.controller';
 @Module({
   imports: [PrismaModule, forwardRef(() => AuthModule)],
-  controllers: [UsersController, UsersProfileController],
+  controllers: [UsersProfileController, UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -6,6 +6,7 @@ import {
 import type { Prisma } from 'generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { RoleName } from '../common/types/role-name.enum';
 import * as bcrypt from 'bcrypt';
@@ -19,6 +20,19 @@ type UserWithRoles = Prisma.UserGetPayload<{
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private async findActiveByIdWithRoles(id: number): Promise<UserWithRoles> {
+    const user = await this.prisma.user.findFirst({
+      where: { id, deletedAt: null },
+      include: { roles: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`Usuario con ID ${id} no encontrado`);
+    }
+
+    return user;
+  }
 
   private formatUserResponse(user: any) {
     if (!user) return null;
@@ -67,15 +81,7 @@ export class UsersService {
   }
 
   async findOne(id: number) {
-    const user = await this.prisma.user.findFirst({
-      where: { id, deletedAt: null },
-      include: { roles: true },
-    });
-
-    if (!user) {
-      throw new NotFoundException(`Usuario con ID ${id} no encontrado`);
-    }
-
+    const user = await this.findActiveByIdWithRoles(id);
     return this.formatUserResponse(user);
   }
 
@@ -124,6 +130,26 @@ export class UsersService {
     const updatedUser = await this.prisma.user.update({
       where: { id },
       data: dataToUpdate,
+      include: { roles: true },
+    });
+
+    return this.formatUserResponse(updatedUser);
+  }
+
+  async findProfileById(userId: number) {
+    const user = await this.findActiveByIdWithRoles(userId);
+    return this.formatUserResponse(user);
+  }
+
+  async updateProfileById(userId: number, updateProfileDto: UpdateProfileDto) {
+    await this.findActiveByIdWithRoles(userId);
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        name: updateProfileDto.name.trim(),
+        surname: updateProfileDto.surname.trim(),
+      },
       include: { roles: true },
     });
 

--- a/frontend/src/components/layout/Header/Header.css
+++ b/frontend/src/components/layout/Header/Header.css
@@ -109,6 +109,21 @@
   box-shadow: none;
 }
 
+.header-action-btn--profile {
+  color: var(--brand-secondary);
+  border: 1px solid rgba(13, 59, 115, 0.32);
+  background: rgba(13, 59, 115, 0.04);
+  box-shadow: none;
+}
+
+.header-action-btn--profile:hover,
+.header-action-btn--profile:focus {
+  color: var(--brand-secondary);
+  border-color: rgba(13, 59, 115, 0.5);
+  background: rgba(13, 59, 115, 0.1);
+  box-shadow: none;
+}
+
 @media (max-width: 1199.98px) {
   .brand-header .nav-link {
     padding-left: 0.55rem;

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -6,6 +6,7 @@ import {
   subscribeToAuthSession,
   userHasAdminRole,
 } from '../../../features/auth/utils/auth-session.storage';
+import { ProfileModal } from '../../../features/profile/components/ProfileModal/ProfileModal';
 import './Header.css';
 import { HeaderBrand } from './shared/HeaderBrand/HeaderBrand';
 import { HeaderNav, type HeaderNavItem } from './shared/HeaderNav/HeaderNav';
@@ -24,6 +25,7 @@ const navItems: HeaderNavItem[] = [
 export const Header = () => {
   const navigate = useNavigate();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [session, setSession] = useState(() => getAuthSession());
 
   useEffect(() => {
@@ -39,9 +41,26 @@ export const Header = () => {
 
   const toggleMenu = () => setIsMenuOpen((prev) => !prev);
   const closeMenu = () => setIsMenuOpen(false);
+
+  const handleOpenProfile = () => {
+    closeMenu();
+    setIsProfileOpen(true);
+  };
+
+  const handleCloseProfile = () => {
+    setIsProfileOpen(false);
+  };
+
+  const handlePasswordChanged = () => {
+    clearAuthSession();
+    setIsProfileOpen(false);
+    navigate('/auth/login', { replace: true });
+  };
+
   const handleLogout = () => {
     clearAuthSession();
     closeMenu();
+    setIsProfileOpen(false);
     navigate('/', { replace: true });
   };
 
@@ -68,11 +87,18 @@ export const Header = () => {
               isAdmin={isAdmin}
               isAuthenticated={isAuthenticated}
               onClose={closeMenu}
+              onProfile={handleOpenProfile}
               onLogout={handleLogout}
             />
           </div>
         </div>
       </nav>
+
+      <ProfileModal
+        isOpen={isProfileOpen}
+        onClose={handleCloseProfile}
+        onPasswordChanged={handlePasswordChanged}
+      />
     </header>
   );
 };

--- a/frontend/src/components/layout/Header/shared/HeaderActions/HeaderActions.tsx
+++ b/frontend/src/components/layout/Header/shared/HeaderActions/HeaderActions.tsx
@@ -4,6 +4,7 @@ type HeaderActionsProps = {
   isAdmin: boolean;
   isAuthenticated: boolean;
   onClose: () => void;
+  onProfile: () => void;
   onLogout: () => void;
 };
 
@@ -11,6 +12,7 @@ export const HeaderActions = ({
   isAdmin,
   isAuthenticated,
   onClose,
+  onProfile,
   onLogout,
 }: HeaderActionsProps) => (
   <div className="d-flex gap-2 header-actions">
@@ -25,6 +27,15 @@ export const HeaderActions = ({
 
     {isAuthenticated ? (
       <>
+        <button
+          type="button"
+          className="btn header-action-btn header-action-btn--profile"
+          onClick={onProfile}
+        >
+          <i className="bi bi-person-circle me-1" aria-hidden="true" />
+          Perfil
+        </button>
+
         {isAdmin ? (
           <Link
             to="/admin"

--- a/frontend/src/features/auth/utils/auth-session.storage.ts
+++ b/frontend/src/features/auth/utils/auth-session.storage.ts
@@ -123,6 +123,15 @@ export const saveAuthSession = (data: AuthResponseData): void => {
   notifyAuthSessionChanged();
 };
 
+export const updateAuthSessionUser = (nextUser: AuthUser): void => {
+  if (!isBrowser) {
+    return;
+  }
+
+  localStorage.setItem(AUTH_USER_STORAGE_KEY, JSON.stringify(nextUser));
+  notifyAuthSessionChanged();
+};
+
 export const clearAuthSession = (): void => {
   if (!isBrowser) {
     return;

--- a/frontend/src/features/profile/api/profile.api.ts
+++ b/frontend/src/features/profile/api/profile.api.ts
@@ -1,0 +1,44 @@
+import type { AxiosResponse } from 'axios';
+import api from '../../../services/http/axios.instance';
+import type { ApiResponse } from '../../../types/api';
+import { getAuthSession } from '../../auth/utils/auth-session.storage';
+import type {
+  ChangePasswordPayload,
+  UpdateProfilePayload,
+  UserProfile,
+} from '../types/profile.types';
+
+const authHeaders = () => {
+  const token = getAuthSession().accessToken;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const handleResponse = <T>(response: AxiosResponse<ApiResponse<T>>) => response.data;
+
+export const getMyProfile = async (): Promise<ApiResponse<UserProfile>> => {
+  const response = await api.get<ApiResponse<UserProfile>>('/users/me', {
+    headers: authHeaders(),
+  });
+
+  return handleResponse(response);
+};
+
+export const updateMyProfile = async (
+  payload: UpdateProfilePayload,
+): Promise<ApiResponse<UserProfile>> => {
+  const response = await api.patch<ApiResponse<UserProfile>>('/users/me', payload, {
+    headers: authHeaders(),
+  });
+
+  return handleResponse(response);
+};
+
+export const changeMyPassword = async (
+  payload: ChangePasswordPayload,
+): Promise<ApiResponse<null>> => {
+  const response = await api.patch<ApiResponse<null>>('/auth/change-password', payload, {
+    headers: authHeaders(),
+  });
+
+  return handleResponse(response);
+};

--- a/frontend/src/features/profile/components/ProfileModal/ProfileModal.css
+++ b/frontend/src/features/profile/components/ProfileModal/ProfileModal.css
@@ -5,50 +5,56 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: 0.8rem;
   background:
-    radial-gradient(circle at 12% 18%, rgba(107, 170, 117, 0.18), transparent 38%),
-    radial-gradient(circle at 88% 82%, rgba(13, 59, 115, 0.2), transparent 42%),
-    rgba(11, 16, 23, 0.48);
-  backdrop-filter: blur(2px);
+    radial-gradient(circle at 16% 22%, rgba(107, 170, 117, 0.24), transparent 40%),
+    radial-gradient(circle at 84% 78%, rgba(13, 59, 115, 0.25), transparent 44%),
+    rgba(11, 16, 23, 0.46);
+  backdrop-filter: blur(3px);
 }
 
 .profile-modal__content {
   position: relative;
-  width: min(940px, 100%);
-  max-height: min(92vh, 760px);
+  width: min(860px, 100%);
+  max-height: min(90vh, 740px);
   overflow: auto;
-  border-radius: 1.1rem;
-  border: 1px solid rgba(13, 59, 115, 0.12);
+  border-radius: 1rem;
+  border: 1px solid rgba(13, 59, 115, 0.16);
   background:
-    linear-gradient(155deg, rgba(255, 255, 255, 0.98), rgba(247, 251, 248, 0.99));
+    linear-gradient(160deg, rgba(255, 255, 255, 0.99), rgba(246, 250, 247, 0.99));
   box-shadow:
-    0 28px 56px rgba(7, 23, 41, 0.28),
+    0 24px 48px rgba(7, 23, 41, 0.28),
     inset 0 1px 0 rgba(255, 255, 255, 0.75);
-  padding: 1.6rem 1.4rem;
+  padding: 1.1rem 1rem 1rem;
   animation: puchRevealUp 340ms cubic-bezier(0.2, 0.75, 0.25, 1) forwards;
 }
 
 .profile-modal__close {
   position: absolute;
-  top: 0.9rem;
-  right: 0.9rem;
+  top: 0.72rem;
+  right: 0.72rem;
   width: 36px;
   height: 36px;
-  border: none;
+  border: 1px solid rgba(13, 59, 115, 0.24);
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--brand-muted);
-  background: rgba(255, 255, 255, 0.72);
+  color: var(--brand-secondary);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 4px 10px rgba(13, 59, 115, 0.12);
   cursor: pointer;
-  transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .profile-modal__close:hover,
 .profile-modal__close:focus {
   color: var(--brand-secondary);
+  border-color: rgba(13, 59, 115, 0.4);
   background: rgba(255, 255, 255, 1);
   transform: translateY(-1px);
 }
@@ -59,30 +65,39 @@
 }
 
 .profile-modal__header {
-  margin-bottom: 0.8rem;
-  padding-right: 2.4rem;
+  margin-bottom: 0.7rem;
+  padding: 0.8rem 2.5rem 0.7rem 0.8rem;
+  border-radius: 0.82rem;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(13, 59, 115, 0.08),
+      rgba(107, 170, 117, 0.14)
+    );
+  border: 1px solid rgba(13, 59, 115, 0.12);
 }
 
 .profile-modal__title {
   margin: 0;
   color: var(--brand-secondary);
   font-family: var(--font-heading);
-  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
+  font-size: clamp(1.22rem, 2vw, 1.48rem);
   font-weight: 800;
 }
 
 .profile-modal__subtitle {
   margin: 0.35rem 0 0;
   color: var(--brand-muted);
-  font-size: 0.92rem;
+  font-size: 0.89rem;
   line-height: 1.5;
 }
 
 .profile-modal__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
-  margin-bottom: 1rem;
+  gap: 0.45rem;
+  margin-bottom: 0.8rem;
+  padding-left: 0.2rem;
 }
 
 .profile-modal__email,
@@ -90,10 +105,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 700;
   border-radius: 999px;
-  padding: 0.3rem 0.65rem;
+  padding: 0.28rem 0.58rem;
 }
 
 .profile-modal__email {
@@ -111,20 +126,34 @@
 .profile-modal__grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.95rem;
+  align-items: stretch;
+  gap: 0.75rem;
 }
 
 .profile-modal__panel {
-  border-radius: 0.9rem;
-  border: 1px solid rgba(13, 59, 115, 0.1);
-  background: rgba(255, 255, 255, 0.86);
-  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  border-radius: 0.84rem;
+  border: 1px solid rgba(13, 59, 115, 0.14);
+  background: rgba(255, 255, 255, 0.94);
+  padding: 0.88rem 0.85rem 0.78rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.profile-modal__panel .auth-form {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.profile-modal__panel .auth-form__submit {
+  margin-top: auto;
 }
 
 .profile-modal__panel-title {
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.62rem;
   color: var(--brand-secondary);
-  font-size: 1rem;
+  font-size: 0.98rem;
   font-weight: 800;
 }
 
@@ -164,7 +193,7 @@
   outline-offset: 2px;
 }
 
-@media (max-width: 991.98px) {
+@media (max-width: 1199.98px) {
   .profile-modal__grid {
     grid-template-columns: 1fr;
   }
@@ -172,10 +201,14 @@
 
 @media (max-width: 575.98px) {
   .profile-modal__content {
-    padding: 1.2rem 0.95rem;
+    padding: 0.95rem 0.72rem 0.78rem;
   }
 
   .profile-modal__panel {
-    padding: 0.9rem 0.8rem;
+    padding: 0.76rem 0.68rem;
+  }
+
+  .profile-modal__header {
+    padding-right: 2.3rem;
   }
 }

--- a/frontend/src/features/profile/components/ProfileModal/ProfileModal.css
+++ b/frontend/src/features/profile/components/ProfileModal/ProfileModal.css
@@ -1,0 +1,181 @@
+.profile-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1080;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(107, 170, 117, 0.18), transparent 38%),
+    radial-gradient(circle at 88% 82%, rgba(13, 59, 115, 0.2), transparent 42%),
+    rgba(11, 16, 23, 0.48);
+  backdrop-filter: blur(2px);
+}
+
+.profile-modal__content {
+  position: relative;
+  width: min(940px, 100%);
+  max-height: min(92vh, 760px);
+  overflow: auto;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(13, 59, 115, 0.12);
+  background:
+    linear-gradient(155deg, rgba(255, 255, 255, 0.98), rgba(247, 251, 248, 0.99));
+  box-shadow:
+    0 28px 56px rgba(7, 23, 41, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  padding: 1.6rem 1.4rem;
+  animation: puchRevealUp 340ms cubic-bezier(0.2, 0.75, 0.25, 1) forwards;
+}
+
+.profile-modal__close {
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--brand-muted);
+  background: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.profile-modal__close:hover,
+.profile-modal__close:focus {
+  color: var(--brand-secondary);
+  background: rgba(255, 255, 255, 1);
+  transform: translateY(-1px);
+}
+
+.profile-modal__close:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+}
+
+.profile-modal__header {
+  margin-bottom: 0.8rem;
+  padding-right: 2.4rem;
+}
+
+.profile-modal__title {
+  margin: 0;
+  color: var(--brand-secondary);
+  font-family: var(--font-heading);
+  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
+  font-weight: 800;
+}
+
+.profile-modal__subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--brand-muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.profile-modal__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-bottom: 1rem;
+}
+
+.profile-modal__email,
+.profile-modal__role {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+}
+
+.profile-modal__email {
+  color: var(--brand-secondary);
+  background: rgba(13, 59, 115, 0.08);
+  border: 1px solid rgba(13, 59, 115, 0.14);
+}
+
+.profile-modal__role {
+  color: #1a5f2d;
+  background: rgba(107, 170, 117, 0.15);
+  border: 1px solid rgba(107, 170, 117, 0.34);
+}
+
+.profile-modal__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.95rem;
+}
+
+.profile-modal__panel {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(13, 59, 115, 0.1);
+  background: rgba(255, 255, 255, 0.86);
+  padding: 1rem;
+}
+
+.profile-modal__panel-title {
+  margin: 0 0 0.75rem;
+  color: var(--brand-secondary);
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.profile-modal__password-wrap {
+  position: relative;
+}
+
+.profile-modal__password-input {
+  padding-right: 2.8rem;
+}
+
+.profile-modal__toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  transform: translateY(-50%);
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: none;
+  color: var(--brand-muted);
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.profile-modal__toggle-password:hover,
+.profile-modal__toggle-password:focus {
+  color: var(--brand-secondary);
+  background: rgba(13, 59, 115, 0.08);
+}
+
+.profile-modal__toggle-password:focus-visible {
+  outline: 3px solid rgba(123, 188, 133, 0.55);
+  outline-offset: 2px;
+}
+
+@media (max-width: 991.98px) {
+  .profile-modal__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .profile-modal__content {
+    padding: 1.2rem 0.95rem;
+  }
+
+  .profile-modal__panel {
+    padding: 0.9rem 0.8rem;
+  }
+}

--- a/frontend/src/features/profile/components/ProfileModal/ProfileModal.tsx
+++ b/frontend/src/features/profile/components/ProfileModal/ProfileModal.tsx
@@ -1,0 +1,474 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ChangeEvent, FormEvent, MouseEvent } from 'react';
+import axios from 'axios';
+import { changeMyPassword, getMyProfile, updateMyProfile } from '../../api/profile.api';
+import type { ChangePasswordPayload, UserProfile } from '../../types/profile.types';
+import type { ApiResponse } from '../../../../types/api';
+import {
+  getAuthSession,
+  updateAuthSessionUser,
+} from '../../../auth/utils/auth-session.storage';
+import './ProfileModal.css';
+
+type ProfileModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onPasswordChanged: () => void;
+};
+
+type FeedbackState = {
+  type: 'success' | 'error';
+  message: string;
+};
+
+const initialPasswordForm: ChangePasswordPayload = {
+  currentPassword: '',
+  newPassword: '',
+  confirmNewPassword: '',
+};
+
+const profileFieldLabels: Record<keyof ChangePasswordPayload, string> = {
+  currentPassword: 'Contraseña actual',
+  newPassword: 'Nueva contraseña',
+  confirmNewPassword: 'Confirmar nueva contraseña',
+};
+
+export const ProfileModal = ({ isOpen, onClose, onPasswordChanged }: ProfileModalProps) => {
+  const sessionUser = getAuthSession().user;
+  const [profile, setProfile] = useState<UserProfile | null>(sessionUser);
+  const [name, setName] = useState(sessionUser?.name ?? '');
+  const [surname, setSurname] = useState(sessionUser?.surname ?? '');
+  const [passwordForm, setPasswordForm] = useState<ChangePasswordPayload>(initialPasswordForm);
+  const [showPassword, setShowPassword] = useState<Record<keyof ChangePasswordPayload, boolean>>({
+    currentPassword: false,
+    newPassword: false,
+    confirmNewPassword: false,
+  });
+  const [isProfileLoading, setIsProfileLoading] = useState(false);
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [profileFeedback, setProfileFeedback] = useState<FeedbackState | null>(null);
+  const [passwordFeedback, setPasswordFeedback] = useState<FeedbackState | null>(null);
+  const logoutTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const user = getAuthSession().user;
+    if (user) {
+      setProfile(user);
+      setName(user.name);
+      setSurname(user.surname);
+    }
+    setPasswordForm(initialPasswordForm);
+    setPasswordFeedback(null);
+    setProfileFeedback(null);
+
+    let isCancelled = false;
+
+    const loadProfile = async () => {
+      setIsProfileLoading(true);
+      setProfileFeedback(null);
+
+      try {
+        const response = await getMyProfile();
+        if (isCancelled) {
+          return;
+        }
+
+        if (response.success && response.data) {
+          setProfile(response.data);
+          setName(response.data.name);
+          setSurname(response.data.surname);
+          updateAuthSessionUser(response.data);
+        } else {
+          setProfileFeedback({
+            type: 'error',
+            message: response.message || 'No se pudo cargar tu perfil',
+          });
+        }
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        setProfileFeedback({
+          type: 'error',
+          message: resolveApiError(error, 'No se pudo cargar tu perfil'),
+        });
+      } finally {
+        if (!isCancelled) {
+          setIsProfileLoading(false);
+        }
+      }
+    };
+
+    void loadProfile();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (logoutTimerRef.current) {
+        window.clearTimeout(logoutTimerRef.current);
+      }
+    };
+  }, []);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleProfileSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    const trimmedSurname = surname.trim();
+
+    if (!trimmedName || !trimmedSurname) {
+      setProfileFeedback({
+        type: 'error',
+        message: 'Nombre y apellidos son obligatorios',
+      });
+      return;
+    }
+
+    setIsSavingProfile(true);
+    setProfileFeedback(null);
+
+    try {
+      const response = await updateMyProfile({
+        name: trimmedName,
+        surname: trimmedSurname,
+      });
+
+      if (response.success && response.data) {
+        setProfile(response.data);
+        setName(response.data.name);
+        setSurname(response.data.surname);
+        updateAuthSessionUser(response.data);
+        setProfileFeedback({
+          type: 'success',
+          message: response.message || 'Perfil actualizado correctamente',
+        });
+        return;
+      }
+
+      setProfileFeedback({
+        type: 'error',
+        message: response.message || 'No se pudo actualizar el perfil',
+      });
+    } catch (error) {
+      setProfileFeedback({
+        type: 'error',
+        message: resolveApiError(error, 'No se pudo actualizar el perfil'),
+      });
+    } finally {
+      setIsSavingProfile(false);
+    }
+  };
+
+  const handlePasswordInput = (
+    field: keyof ChangePasswordPayload,
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    setPasswordForm((previous) => ({
+      ...previous,
+      [field]: event.target.value,
+    }));
+    setPasswordFeedback(null);
+  };
+
+  const togglePasswordVisibility = (field: keyof ChangePasswordPayload) => {
+    setShowPassword((previous) => ({
+      ...previous,
+      [field]: !previous[field],
+    }));
+  };
+
+  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const currentPassword = passwordForm.currentPassword.trim();
+    const newPassword = passwordForm.newPassword.trim();
+    const confirmNewPassword = passwordForm.confirmNewPassword.trim();
+
+    if (!currentPassword || !newPassword || !confirmNewPassword) {
+      setPasswordFeedback({
+        type: 'error',
+        message: 'Completa todos los campos de contraseña',
+      });
+      return;
+    }
+
+    if (newPassword === currentPassword) {
+      setPasswordFeedback({
+        type: 'error',
+        message: 'La nueva contraseña debe ser distinta de la actual',
+      });
+      return;
+    }
+
+    if (newPassword !== confirmNewPassword) {
+      setPasswordFeedback({
+        type: 'error',
+        message: 'La confirmación no coincide con la nueva contraseña',
+      });
+      return;
+    }
+
+    setIsChangingPassword(true);
+    setPasswordFeedback(null);
+
+    try {
+      const response = await changeMyPassword({
+        currentPassword,
+        newPassword,
+        confirmNewPassword,
+      });
+
+      if (!response.success) {
+        setPasswordFeedback({
+          type: 'error',
+          message: response.message || 'No se pudo cambiar la contraseña',
+        });
+        return;
+      }
+
+      setPasswordFeedback({
+        type: 'success',
+        message:
+          'Contraseña actualizada correctamente. Se cerrará tu sesión por seguridad.',
+      });
+      setPasswordForm(initialPasswordForm);
+
+      logoutTimerRef.current = window.setTimeout(() => {
+        onPasswordChanged();
+      }, 900);
+    } catch (error) {
+      setPasswordFeedback({
+        type: 'error',
+        message: resolveApiError(error, 'No se pudo cambiar la contraseña'),
+      });
+    } finally {
+      setIsChangingPassword(false);
+    }
+  };
+
+  return (
+    <div
+      className="profile-modal__backdrop"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="profile-modal-title"
+    >
+      <div className="profile-modal__content">
+        <button
+          className="profile-modal__close"
+          onClick={onClose}
+          aria-label="Cerrar perfil"
+          type="button"
+          disabled={isChangingPassword}
+        >
+          <i className="bi bi-x-lg" aria-hidden="true" />
+        </button>
+
+        <header className="profile-modal__header">
+          <h2 className="profile-modal__title" id="profile-modal-title">
+            Tu perfil
+          </h2>
+          <p className="profile-modal__subtitle">
+            Gestiona tus datos personales y la seguridad de tu cuenta.
+          </p>
+        </header>
+
+        <div className="profile-modal__meta">
+          <span className="profile-modal__email">
+            <i className="bi bi-envelope" aria-hidden="true" />
+            {profile?.email ?? sessionUser?.email ?? 'Sin email'}
+          </span>
+          <span className="profile-modal__role">
+            {(profile?.roles?.[0] ?? sessionUser?.roles?.[0] ?? 'USER').toUpperCase()}
+          </span>
+        </div>
+
+        <div className="profile-modal__grid">
+          <section className="profile-modal__panel">
+            <h3 className="profile-modal__panel-title">Datos personales</h3>
+
+            <form className="auth-form" onSubmit={handleProfileSubmit} noValidate>
+              <div className="auth-form__field">
+                <label className="auth-form__label" htmlFor="profile-name">
+                  Nombre
+                </label>
+                <input
+                  id="profile-name"
+                  className="auth-form__input"
+                  type="text"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  disabled={isProfileLoading || isSavingProfile || isChangingPassword}
+                  maxLength={80}
+                  autoComplete="given-name"
+                  required
+                />
+              </div>
+
+              <div className="auth-form__field">
+                <label className="auth-form__label" htmlFor="profile-surname">
+                  Apellidos
+                </label>
+                <input
+                  id="profile-surname"
+                  className="auth-form__input"
+                  type="text"
+                  value={surname}
+                  onChange={(event) => setSurname(event.target.value)}
+                  disabled={isProfileLoading || isSavingProfile || isChangingPassword}
+                  maxLength={120}
+                  autoComplete="family-name"
+                  required
+                />
+              </div>
+
+              {profileFeedback ? (
+                <div
+                  className={`auth-form__feedback auth-form__feedback--${profileFeedback.type}`}
+                  role={profileFeedback.type === 'error' ? 'alert' : 'status'}
+                >
+                  <i
+                    className={`bi ${
+                      profileFeedback.type === 'success'
+                        ? 'bi-check-circle-fill'
+                        : 'bi-exclamation-circle-fill'
+                    }`}
+                    aria-hidden="true"
+                  />
+                  {profileFeedback.message}
+                </div>
+              ) : null}
+
+              <button
+                type="submit"
+                className="btn-brand-auth auth-form__submit"
+                disabled={isProfileLoading || isSavingProfile || isChangingPassword}
+              >
+                {isSavingProfile ? 'Guardando...' : 'Guardar perfil'}
+              </button>
+            </form>
+          </section>
+
+          <section className="profile-modal__panel">
+            <h3 className="profile-modal__panel-title">Seguridad</h3>
+
+            <form className="auth-form" onSubmit={handlePasswordSubmit} noValidate>
+              {(Object.keys(passwordForm) as Array<keyof ChangePasswordPayload>).map((field) => (
+                <div className="auth-form__field" key={field}>
+                  <label className="auth-form__label" htmlFor={`profile-${field}`}>
+                    {profileFieldLabels[field]}
+                  </label>
+
+                  <div className="profile-modal__password-wrap">
+                    <input
+                      id={`profile-${field}`}
+                      className="auth-form__input profile-modal__password-input"
+                      type={showPassword[field] ? 'text' : 'password'}
+                      value={passwordForm[field]}
+                      onChange={(event) => handlePasswordInput(field, event)}
+                      disabled={isChangingPassword}
+                      autoComplete={
+                        field === 'currentPassword' ? 'current-password' : 'new-password'
+                      }
+                      required
+                    />
+                    <button
+                      type="button"
+                      className="profile-modal__toggle-password"
+                      onClick={() => togglePasswordVisibility(field)}
+                      aria-label={
+                        showPassword[field]
+                          ? `Ocultar ${profileFieldLabels[field].toLowerCase()}`
+                          : `Mostrar ${profileFieldLabels[field].toLowerCase()}`
+                      }
+                      disabled={isChangingPassword}
+                    >
+                      <i
+                        className={`bi ${showPassword[field] ? 'bi-eye-slash' : 'bi-eye'}`}
+                        aria-hidden="true"
+                      />
+                    </button>
+                  </div>
+                </div>
+              ))}
+
+              {passwordFeedback ? (
+                <div
+                  className={`auth-form__feedback auth-form__feedback--${passwordFeedback.type}`}
+                  role={passwordFeedback.type === 'error' ? 'alert' : 'status'}
+                >
+                  <i
+                    className={`bi ${
+                      passwordFeedback.type === 'success'
+                        ? 'bi-check-circle-fill'
+                        : 'bi-exclamation-circle-fill'
+                    }`}
+                    aria-hidden="true"
+                  />
+                  {passwordFeedback.message}
+                </div>
+              ) : null}
+
+              <button
+                type="submit"
+                className="btn-brand-auth auth-form__submit"
+                disabled={isChangingPassword}
+              >
+                {isChangingPassword ? 'Actualizando...' : 'Cambiar contraseña'}
+              </button>
+            </form>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const resolveApiError = (error: unknown, fallbackMessage: string): string => {
+  if (axios.isAxiosError(error)) {
+    const backendError = error.response?.data as ApiResponse<null> | undefined;
+    if (backendError?.message) {
+      return backendError.message;
+    }
+  }
+
+  return fallbackMessage;
+};

--- a/frontend/src/features/profile/types/profile.types.ts
+++ b/frontend/src/features/profile/types/profile.types.ts
@@ -1,0 +1,14 @@
+import type { AuthUser } from '../../auth/types/auth.api.types';
+
+export type UserProfile = AuthUser;
+
+export type UpdateProfilePayload = {
+  name: string;
+  surname: string;
+};
+
+export type ChangePasswordPayload = {
+  currentPassword: string;
+  newPassword: string;
+  confirmNewPassword: string;
+};


### PR DESCRIPTION
## 📌 Resumen

Implementación completa de **HU-30: Perfil de usuario y cambio de contraseña** (backend + frontend + diseño), con microcommits y ajustes funcionales/visuales finales.

## ✅ Backend

- `GET /users/me` para consultar perfil del usuario autenticado.
- `PATCH /users/me` para actualizar `name` y `surname`.
- `PATCH /auth/change-password` para cambio de contraseña desde sesión activa.
- Validaciones backend:
  - contraseña actual correcta,
  - nueva distinta de actual,
  - confirmación igual a nueva,
  - mínimo 6 caracteres (compatibilidad con usuarios existentes).
- Ajuste de enrutado para priorizar correctamente `/users/me`.

## ✅ Frontend

- Botón `Perfil` en Header cuando hay sesión activa.
- Modal de perfil con dos bloques:
  - Datos personales.
  - Seguridad (cambio de contraseña).
- Inputs de contraseña con mostrar/ocultar (`ojo`).
- Estados de loading/error/success y prevención de doble submit.
- Tras cambio de contraseña exitoso: cierre de sesión y redirección a login.
- Ajustes de diseño:
  - alineación de botones verdes a la misma altura,
  - mejora de contraste del botón `X` de cierre,
  - modal más compacto en portátil.

## 🧪 Pruebas realizadas

### Calidad
- `yarn --cwd backend build` ✅
- `yarn --cwd frontend lint` ✅
- `yarn --cwd frontend build` ✅

### Runtime (Docker)
- `docker compose up -d --build backend frontend nginx` ✅
- Endpoints en ejecución:
  - `/api/users/me` (401 sin token, 200 con token)
  - `/api/auth/change-password` (401 sin token, 200 con token)
- Flujo E2E validado:
  - registro,
  - actualización de perfil,
  - cambio de contraseña,
  - login falla con contraseña antigua y funciona con la nueva.

