### PR TITLE
Feature/hu 42 quick faq chatbot

### DIFF
--- a/backend/src/chatbot/chatbot-orchestrator.service.ts
+++ b/backend/src/chatbot/chatbot-orchestrator.service.ts
@@ -431,6 +431,14 @@ export class ChatbotOrchestratorService {
   }
 
   private detectPreferredIntentCode(normalizedText: string) {
+    if (/\bdonar\b|\bdonacion\w*\b/.test(normalizedText)) {
+      return 'DONAR';
+    }
+
+    if (/\bcolaborar\b|\bvoluntariado\b/.test(normalizedText)) {
+      return 'COLABORAR';
+    }
+
     if (/\bnotici\w*\b/.test(normalizedText)) {
       return 'NOTICIAS';
     }

--- a/backend/src/chatbot/seed/chatbot-seed.source.ts
+++ b/backend/src/chatbot/seed/chatbot-seed.source.ts
@@ -127,6 +127,13 @@ export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
     weight: 0.95,
     isActive: true,
   },
+  {
+    intentCode: 'EQUIPO_PUCH_OVERVIEW',
+    text: 'que es equipo puch y cual es su objetivo',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
 
   {
     intentCode: 'UNIRSE_EQUIPO_PUCH',
@@ -192,6 +199,13 @@ export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
     weight: 0.9,
     isActive: true,
   },
+  {
+    intentCode: 'PROYECTOS_INTERNACIONALES',
+    text: 'que proyectos apoyais actualmente',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
 
   {
     intentCode: 'DONAR',
@@ -249,6 +263,13 @@ export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
     weight: 0.95,
     isActive: true,
   },
+  {
+    intentCode: 'DONAR',
+    text: 'como puedo donar a equipo puch',
+    language: 'es',
+    weight: 1,
+    isActive: true,
+  },
 
   {
     intentCode: 'COLABORAR',
@@ -269,6 +290,13 @@ export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
     text: 'como participar en la red solidaria',
     language: 'es',
     weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'COLABORAR',
+    text: 'como puedo colaborar o hacer voluntariado',
+    language: 'es',
+    weight: 1,
     isActive: true,
   },
 
@@ -319,6 +347,13 @@ export const CHATBOT_SEED_INTENT_PHRASES: ChatbotSeedIntentPhrase[] = [
     text: 'informacion de esta noticia',
     language: 'es',
     weight: 0.9,
+    isActive: true,
+  },
+  {
+    intentCode: 'NOTICIAS',
+    text: 'donde puedo ver noticias de la iniciativa',
+    language: 'es',
+    weight: 1,
     isActive: true,
   },
 

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useChatbot } from '../../hooks/useChatbot';
 import type { ChatbotCtaLink } from '../../types/chatbot.types';
+import { QuickFaq } from '../QuickFaq/QuickFaq';
 import { ChatbotLauncherButton } from './parts/ChatbotLauncherButton';
 import { ChatbotMessageItem } from './parts/ChatbotMessageItem';
 import './ChatbotWidget.css';
@@ -118,6 +119,14 @@ export function ChatbotWidget() {
                 onFeedback={handleFeedback}
               />
             ))}
+
+            {messages.length <= 1 && (
+              <QuickFaq
+                disabled={isSending}
+                onSelect={handleSuggestionClick}
+              />
+            )}
+
             {isSending && (
               <div className="chatbot-message chatbot-message--bot chatbot-message--typing">
                 <span className="chatbot-typing-dot" />

--- a/frontend/src/features/chatbot/components/QuickFaq/QuickFaq.css
+++ b/frontend/src/features/chatbot/components/QuickFaq/QuickFaq.css
@@ -1,0 +1,44 @@
+.quick-faq {
+  padding: 0.5rem 0.8rem 0.2rem;
+}
+
+.quick-faq__title {
+  margin: 0 0 0.42rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(13, 59, 115, 0.55);
+}
+
+.quick-faq__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.36rem;
+}
+
+.quick-faq__chip {
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.62rem;
+  color: #1f5f4a;
+  border: 1px solid rgba(58, 128, 72, 0.26);
+  background: rgba(107, 170, 117, 0.12);
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+  line-height: 1.3;
+  text-align: left;
+}
+
+.quick-faq__chip:hover,
+.quick-faq__chip:focus-visible {
+  border-color: rgba(58, 128, 72, 0.5);
+  background: rgba(107, 170, 117, 0.24);
+  outline: none;
+}
+
+.quick-faq__chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/features/chatbot/components/QuickFaq/QuickFaq.tsx
+++ b/frontend/src/features/chatbot/components/QuickFaq/QuickFaq.tsx
@@ -1,0 +1,35 @@
+import { getVisibleFaqs } from '../../constants/quickFaq';
+import './QuickFaq.css';
+
+type QuickFaqProps = {
+  disabled: boolean;
+  onSelect: (message: string) => void;
+};
+
+const faqs = getVisibleFaqs();
+
+export function QuickFaq({ disabled, onSelect }: QuickFaqProps) {
+  if (faqs.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="quick-faq" aria-label="Preguntas frecuentes">
+      <p className="quick-faq__title">Preguntas frecuentes</p>
+      <div className="quick-faq__chips" role="list">
+        {faqs.map((faq) => (
+          <button
+            key={faq.id}
+            type="button"
+            role="listitem"
+            className="quick-faq__chip"
+            disabled={disabled}
+            onClick={() => onSelect(faq.message)}
+          >
+            {faq.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/chatbot/constants/quickFaq.ts
+++ b/frontend/src/features/chatbot/constants/quickFaq.ts
@@ -1,0 +1,53 @@
+export type QuickFaqItem = {
+  id: string;
+  label: string;
+  message: string;
+  order: number;
+  isActive: boolean;
+};
+
+export const QUICK_FAQ_ITEMS: QuickFaqItem[] = [
+  {
+    id: 'faq-donate',
+    label: '💰 ¿Cómo puedo donar?',
+    message: '¿Cómo puedo donar a Equipo PUCH?',
+    order: 1,
+    isActive: true,
+  },
+  {
+    id: 'faq-volunteer',
+    label: '🤝 ¿Cómo colaborar?',
+    message: '¿Cómo puedo colaborar o hacer voluntariado?',
+    order: 2,
+    isActive: true,
+  },
+  {
+    id: 'faq-projects',
+    label: '🌍 Proyectos actuales',
+    message: '¿Qué proyectos apoyáis actualmente?',
+    order: 3,
+    isActive: true,
+  },
+  {
+    id: 'faq-news',
+    label: '📰 Noticias recientes',
+    message: '¿Dónde puedo ver noticias de la iniciativa?',
+    order: 4,
+    isActive: true,
+  },
+  {
+    id: 'faq-about',
+    label: '❓ ¿Qué es Equipo PUCH?',
+    message: '¿Qué es Equipo PUCH y cuál es su objetivo?',
+    order: 5,
+    isActive: true,
+  },
+];
+
+const MAX_VISIBLE_FAQS = 6;
+
+export function getVisibleFaqs(): QuickFaqItem[] {
+  return QUICK_FAQ_ITEMS.filter((faq) => faq.isActive)
+    .sort((a, b) => a.order - b.order)
+    .slice(0, MAX_VISIBLE_FAQS);
+}


### PR DESCRIPTION
## HU-42 — Asistente PUCH: Preguntas frecuentes clicables (Quick FAQ)

### Descripción

Implementa un bloque de **preguntas rápidas frecuentes (chips)** dentro del panel del chatbot para reducir fricción y guiar a usuarios nuevos. Al abrir el chat se muestran 5 FAQs clicables que envían el mensaje directamente al pipeline existente sin necesidad de endpoint nuevo.

### Cambios realizados

**Frontend**
- Nuevo componente `QuickFaq` con chips clicables y estilos coherentes con el diseño actual.
- Constantes tipadas (`QuickFaqItem`) con las 5 FAQs iniciales, separando `label` (texto visible) de `message` (texto enviado al backend).
- Integración en `ChatbotWidget`: los chips se muestran solo en la vista inicial (≤1 mensaje) y se deshabilitan durante el envío para evitar doble click.

**Backend**
- Añadidos intent hints para `DONAR` y `COLABORAR` en `detectPreferredIntentCode()`, que antes solo cubría noticias, delegaciones, superhéroes y retos.
- Añadidas 5 frases seed alineadas con los mensajes exactos de las Quick FAQs para maximizar el matching del motor NLP.

### FAQs incluidas

| Chip | Mensaje enviado |
|------|----------------|
| 💰 ¿Cómo puedo donar? | ¿Cómo puedo donar a Equipo PUCH? |
| 🤝 ¿Cómo colaborar? | ¿Cómo puedo colaborar o hacer voluntariado? |
| 🌍 Proyectos actuales | ¿Qué proyectos apoyáis actualmente? |
| 📰 Noticias recientes | ¿Dónde puedo ver noticias de la iniciativa? |
| ❓ ¿Qué es Equipo PUCH? | ¿Qué es Equipo PUCH y cuál es su objetivo? |

### Notas

- Requiere ejecutar `yarn prisma:seed` tras desplegar para insertar las nuevas frases en la base de datos.
- No altera el contrato de `/chatbot/message` ni `/chatbot/suggestions`.
- Compatible con HU-39 (panel base) y HU-40 (sugerencias dinámicas).