### PR TITLE
Fix montaje Docker y login con Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ docker compose up --build
 Esto realiza los siguientes pasos:
 - Construye las imágenes.
 - Instala dependencias dentro de Docker.
+- Aplica migraciones y carga los seeds iniciales de desarrollo.
 - Levanta frontend, backend, base de datos, redis y nginx.
 
 La aplicación quedará disponible en: [http://localhost](http://localhost)
@@ -127,7 +128,7 @@ docker compose down -v
 
 ---
 
-## 📦 Ejecutar comandos dentro del contenedor (\`docker exec\`)
+## 📦 Ejecutar comandos dentro del contenedor (\`docker compose exec\`)
 
 Se usa para ejecutar comandos dentro de un contenedor que ya está corriendo.
 
@@ -146,7 +147,7 @@ Verás algo como:
 **2. Entrar al backend:**
 
 ```bash
-docker exec -it proyectoproclade-backend-1 sh
+docker compose exec backend sh
 ```
 - Salir escribiendo: `exit`
 
@@ -154,17 +155,17 @@ docker exec -it proyectoproclade-backend-1 sh
 
 - **Instalar una dependencia en el backend:**
   ```bash
-  docker exec -it proyectoproclade-backend-1 yarn add bcrypt
+  docker compose exec backend yarn add bcrypt
   ```
 
 - **Instalar una dependencia de desarrollo:**
   ```bash
-  docker exec -it proyectoproclade-backend-1 yarn add -D @types/bcrypt
+  docker compose exec backend yarn add -D @types/bcrypt
   ```
 
 - **Ejecutar Prisma:**
   ```bash
-  docker exec -it proyectoproclade-backend-1 yarn prisma migrate dev
+  docker compose exec backend yarn prisma migrate dev
   ```
 
 ### ❓ ¿Puedo ejecutar estos comandos desde VS Code?
@@ -294,17 +295,20 @@ Debe verse `__metadata` y `version: 8`.
 ## Seeds (Datos de prueba)
 
 El proyecto incluye un sistema de seeds reproducible e idempotente para poblar la base de datos con datos de prueba.
+Estos seeds se ejecutan automáticamente durante `docker compose up --build`, por lo que el proyecto queda listo para probar al terminar el arranque.
 
 ### Ejecutar seeds
 
+Si necesitas relanzarlos manualmente:
 
+```bash
 # Aplicar migraciones a la DB
-```bash
-docker exec proyecto-proclade-backend-1 yarn prisma migrate deploy
+docker compose exec backend yarn prisma migrate deploy
 ```
-# Poblar datos de prueba (opcional)
+
 ```bash
-docker exec proyecto-proclade-backend-1 yarn prisma:seed
+# Poblar datos de prueba otra vez
+docker compose exec backend yarn prisma:seed
 ```
 
 ### Datos creados

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,7 +18,7 @@ SMTP_PASS=
 MAIL_FROM=proclade.pass@gmail.com
 
 # ─── Password Reset ───
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=http://localhost
 RESET_PASSWORD_TTL_MINUTES=30
 
 # ─── Chatbot matching (HU-40) ───

--- a/backend/scripts/docker-start-dev.sh
+++ b/backend/scripts/docker-start-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+yarn exec prisma generate
+yarn exec prisma migrate deploy
+yarn prisma:seed
+exec yarn start:dev

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,115 @@
+import * as bcrypt from 'bcrypt';
+import { RoleName } from '../common/types/role-name.enum';
+import { AuthService } from './auth.service';
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  const jwtServiceMock = {
+    sign: jest.fn().mockReturnValue('signed-jwt-token'),
+  };
+
+  const configServiceMock = {
+    get: jest.fn(),
+  };
+
+  const googleAuthServiceMock = {
+    verifyIdToken: jest.fn(),
+  };
+
+  const usersServiceMock = {
+    findActiveByEmailWithRoles: jest.fn(),
+  };
+
+  const mailServiceMock = {
+    sendResetPasswordEmail: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+
+    service = new AuthService(
+      prismaMock as never,
+      jwtServiceMock as never,
+      configServiceMock as never,
+      googleAuthServiceMock as never,
+      usersServiceMock as never,
+      mailServiceMock as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registra usuarios creando el rol USER si la base esta vacia', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    prismaMock.user.create.mockImplementation(async (args) => ({
+      id: 101,
+      email: args.data.email,
+      passwordHash: 'hashed-password',
+      name: args.data.name,
+      surname: args.data.surname,
+      google: false,
+      resetPasswordTokenHash: null,
+      resetPasswordExpiresAt: null,
+      deletedAt: null,
+      isRealHero: false,
+      realHeroSuperheroId: null,
+      realHeroSuperhero: null,
+      createdAt: new Date('2026-05-07T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-07T00:00:00.000Z'),
+      roles: [{ name: RoleName.USER }],
+    }));
+
+    const result = await service.register({
+      email: 'nuevo.usuario@test.local',
+      password: 'Secret123!',
+      name: 'Nuevo',
+      surname: 'Usuario',
+    });
+
+    expect(prismaMock.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'nuevo.usuario@test.local',
+        passwordHash: 'hashed-password',
+        name: 'Nuevo',
+        surname: 'Usuario',
+        roles: {
+          connectOrCreate: [
+            {
+              where: { name: RoleName.USER },
+              create: { name: RoleName.USER },
+            },
+          ],
+        },
+      },
+      include: {
+        roles: true,
+        realHeroSuperhero: true,
+      },
+    });
+    expect(result.message).toBe('Registro completado correctamente');
+    expect(result.user.roles).toEqual([RoleName.USER]);
+    expect(jwtServiceMock.sign).toHaveBeenCalledWith({
+      sub: 101,
+      email: 'nuevo.usuario@test.local',
+      roles: [RoleName.USER],
+    });
+  });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -87,16 +87,6 @@ export class AuthService {
       throw new ConflictException('El email ya está registrado');
     }
 
-    const userRole = await this.prisma.role.findUnique({
-      where: {
-        name: RoleName.USER,
-      },
-    });
-
-    if (!userRole) {
-      throw new NotFoundException('No existe el rol USER');
-    }
-
     const hashedPassword = await bcrypt.hash(registerDto.password, 10);
 
     const user = await this.prisma.user.create({
@@ -106,9 +96,16 @@ export class AuthService {
         name: registerDto.name,
         surname: registerDto.surname,
         roles: {
-          connect: {
-            id: userRole.id,
-          },
+          connectOrCreate: [
+            {
+              where: {
+                name: RoleName.USER,
+              },
+              create: {
+                name: RoleName.USER,
+              },
+            },
+          ],
         },
       },
       include: {
@@ -137,16 +134,6 @@ export class AuthService {
     let user = await this.usersService.findActiveByEmailWithRoles(email);
 
     if (!user) {
-      const userRole = await this.prisma.role.findUnique({
-        where: {
-          name: RoleName.USER,
-        },
-      });
-
-      if (!userRole) {
-        throw new NotFoundException('No existe el rol USER');
-      }
-
       const name = googlePayload.name?.trim() || 'Usuario';
       const surname = googlePayload.surname?.trim() || 'Google';
       const randomPassword = randomBytes(24).toString('hex');
@@ -160,9 +147,16 @@ export class AuthService {
           surname,
           google: true,
           roles: {
-            connect: {
-              id: userRole.id,
-            },
+            connectOrCreate: [
+              {
+                where: {
+                  name: RoleName.USER,
+                },
+                create: {
+                  name: RoleName.USER,
+                },
+              },
+            ],
           },
         },
         include: {

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -14,7 +14,7 @@ export class MailService {
     this.mailFrom =
       this.configService.get<string>('MAIL_FROM') || 'noreply@proclade.org';
     this.frontendUrl =
-      this.configService.get<string>('FRONTEND_URL') || 'http://localhost:5173';
+      this.configService.get<string>('FRONTEND_URL') || 'http://localhost';
 
     this.transporter = nodemailer.createTransport({
       host: this.configService.get<string>('SMTP_HOST'),

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,0 +1,84 @@
+import * as bcrypt from 'bcrypt';
+import { RoleName } from '../common/types/role-name.enum';
+import { UsersService } from './users.service';
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    superhero: {
+      update: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+    service = new UsersService(prismaMock as never);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('crea usuarios con rol USER por defecto aunque el rol no exista todavia', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    prismaMock.user.create.mockImplementation(async (args) => ({
+      id: 201,
+      email: args.data.email,
+      passwordHash: 'hashed-password',
+      name: args.data.name,
+      surname: args.data.surname,
+      google: false,
+      resetPasswordTokenHash: null,
+      resetPasswordExpiresAt: null,
+      deletedAt: null,
+      isRealHero: false,
+      realHeroSuperheroId: null,
+      realHeroSuperhero: null,
+      createdAt: new Date('2026-05-07T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-07T00:00:00.000Z'),
+      roles: [{ name: RoleName.USER }],
+    }));
+
+    const result = await service.create({
+      email: 'panel.usuario@test.local',
+      password: 'Secret123!',
+      name: 'Panel',
+      surname: 'Usuario',
+    });
+
+    expect(prismaMock.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'panel.usuario@test.local',
+        passwordHash: 'hashed-password',
+        name: 'Panel',
+        surname: 'Usuario',
+        roles: {
+          connectOrCreate: [
+            {
+              where: { name: RoleName.USER },
+              create: { name: RoleName.USER },
+            },
+          ],
+        },
+      },
+      include: { roles: true },
+    });
+    expect(result.roles).toEqual([RoleName.USER]);
+  });
+});

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -57,15 +57,28 @@ export class UsersService {
     }
 
     const passwordHash = await bcrypt.hash(password, 10);
-    const rolesToConnect = roles?.length ? roles : [RoleName.USER];
+    const usesDefaultUserRole = !roles?.length;
 
     const user = await this.prisma.user.create({
       data: {
         ...rest,
         passwordHash,
-        roles: {
-          connect: rolesToConnect.map((roleName) => ({ name: roleName })),
-        },
+        roles: usesDefaultUserRole
+          ? {
+              connectOrCreate: [
+                {
+                  where: {
+                    name: RoleName.USER,
+                  },
+                  create: {
+                    name: RoleName.USER,
+                  },
+                },
+              ],
+            }
+          : {
+              connect: roles.map((roleName) => ({ name: roleName })),
+            },
       },
       include: { roles: true },
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    command: >
-      sh -c "yarn exec prisma generate &&
-             yarn exec prisma migrate deploy &&
-             yarn start:dev"
+    command: ["sh", "./scripts/docker-start-dev.sh"]
   
 
   ### FRONTEND 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -6,7 +6,7 @@ server {
   add_header X-Frame-Options SAMEORIGIN always;
   add_header Referrer-Policy strict-origin-when-cross-origin always;
   add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), gyroscope=(), magnetometer=(), accelerometer=(), payment=(), interest-cohort=()" always;
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-src 'self' https://www.google.com https://maps.google.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.gstatic.com https://*.googleusercontent.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://accounts.google.com https://*.google.com; frame-src 'self' https://accounts.google.com https://www.google.com https://maps.google.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;
 
   # Excepción: mantener disponible .well-known (ACME/challenges u otros usos controlados)
   location ^~ /.well-known/ {


### PR DESCRIPTION
## Qué cambia
- automatiza `prisma generate`, migraciones y seeds durante `docker compose up --build`
- hace robusta la creación del rol `USER` para registro, alta con Google y creación de usuarios por defecto
- alinea la URL pública de `localhost` en documentación y enlaces funcionales
- permite Google Identity Services en la CSP de `nginx`

## Causa raíz
- el stack Docker levantaba la aplicación pero no ejecutaba seeds, así que una instalación limpia no tenía roles ni usuarios base
- el flujo de Google estaba bloqueado por la `Content-Security-Policy` de `nginx`, que no permitía cargar `accounts.google.com`

## Impacto
- una instalación nueva queda utilizable con `docker compose up --build`
- un entorno viejo puede resetearse con `docker compose down -v` y volver a montarse sin pasos manuales extra
- login seeded, registro normal y login/alta con Google dejan de depender de una base precargada manualmente

## Validación
- `yarn build` en backend
- `yarn test --runInBand auth/auth.service.spec.ts users/users.service.spec.ts`
- `docker compose down -v`
- `docker compose up --build -d`
- login con `admin@proclade.local / Admin123!`
- login con `user@proclade.local / User123!`
- registro de un usuario nuevo
- comprobación de endpoints públicos, admin y creación de sesión de chatbot
- verificación de que no se reprodujeron `EADDRINUSE` ni el error histórico de `Region.updatedAt` tras el remontaje limpio