### PR TITLE
Fix arranque Docker en Windows por line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/scripts/docker-start-dev.sh
+++ b/backend/scripts/docker-start-dev.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Keep LF line endings: /bin/sh in Docker can fail on CRLF checkouts.
 set -eu
 
 yarn exec prisma generate


### PR DESCRIPTION
## Qué cambia
- añade `.gitattributes` con `*.sh text eol=lf`
- actualiza `backend/scripts/docker-start-dev.sh` para dejar explícito que debe mantenerse con finales de línea `LF`

## Causa raíz
En instalaciones nuevas sobre Windows, Git podía dejar `backend/scripts/docker-start-dev.sh` con finales de línea `CRLF`. Dentro del contenedor Linux, `/bin/sh` fallaba al ejecutar el script y el backend no llegaba a arrancar, provocando después errores derivados en `nginx`.

## Impacto
- los clones nuevos en Windows ya no deberían romper el arranque de Docker por este motivo
- el script de bootstrap del backend se mantiene compatible con `/bin/sh` dentro del contenedor

## Validación
- comprobación de sintaxis con `sh -n backend/scripts/docker-start-dev.sh`
- comprobación de atributos Git con `git ls-files --eol backend/scripts/docker-start-dev.sh`
- confirmación del error original reportado por el compañero: `set: Illegal option -` en `docker-start-dev.sh`