### PR TITLE
Feat/hu 28 rgpd privacidad cookies

### DIFF
--- a/backend/prisma/migrations/20260515120000_add_privacy_accepted_at/migration.sql
+++ b/backend/prisma/migrations/20260515120000_add_privacy_accepted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "privacyAcceptedAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   resetPasswordTokenHash     String?
   resetPasswordExpiresAt     DateTime?
   deletedAt                  DateTime?
+  privacyAcceptedAt          DateTime?
   isRealHero                 Boolean               @default(false)
   realHeroSuperheroId        Int?                  @unique
   realHeroSuperhero          Superhero?            @relation("UserRealHero", fields: [realHeroSuperheroId], references: [id])

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -76,6 +76,7 @@ describe('AuthService', () => {
       password: 'Secret123!',
       name: 'Nuevo',
       surname: 'Usuario',
+      privacyAccepted: true,
     });
 
     expect(prismaMock.user.create).toHaveBeenCalledWith({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -86,6 +86,7 @@ export class AuthService {
         passwordHash: hashedPassword,
         name: registerDto.name,
         surname: registerDto.surname,
+        privacyAcceptedAt: new Date(),
         roles: {
           connectOrCreate: [
             {

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString, Matches } from 'class-validator';
+import { Equals, IsBoolean, IsEmail, IsNotEmpty, IsString, Matches } from 'class-validator';
 import {
   PASSWORD_POLICY_MESSAGE,
   PASSWORD_POLICY_REGEX,
@@ -23,4 +23,10 @@ export class RegisterDto {
     message: PASSWORD_POLICY_MESSAGE,
   })
   password: string;
+
+  @IsBoolean({ message: 'La aceptación de la Política de privacidad es obligatoria' })
+  @Equals(true, {
+    message: 'Debes aceptar la Política de privacidad para crear una cuenta',
+  })
+  privacyAccepted: boolean;
 }

--- a/backend/src/colabora/colabora.service.ts
+++ b/backend/src/colabora/colabora.service.ts
@@ -7,6 +7,9 @@ export class ColaboraService {
   constructor(private readonly mailService: MailService) {}
 
   async sendContactForm(contactData: ContactFormDto): Promise<void> {
-    await this.mailService.sendContactEmail(contactData);
+    await this.mailService.sendContactEmail({
+      ...contactData,
+      acceptedAt: new Date(),
+    });
   }
 }

--- a/backend/src/colabora/dto/contact-form.dto.ts
+++ b/backend/src/colabora/dto/contact-form.dto.ts
@@ -1,5 +1,7 @@
 import { Transform } from 'class-transformer';
 import {
+  Equals,
+  IsBoolean,
   IsEmail,
   IsNotEmpty,
   IsOptional,
@@ -52,4 +54,10 @@ export class ContactFormDto {
   @IsString({ message: 'El mensaje debe ser texto' })
   @MaxLength(2000, { message: 'El mensaje no puede superar 2000 caracteres' })
   mensaje?: string;
+
+  @IsBoolean({ message: 'La aceptación de la Política de privacidad es obligatoria' })
+  @Equals(true, {
+    message: 'Debes aceptar la Política de privacidad para enviar el formulario',
+  })
+  privacyAccepted: boolean;
 }

--- a/backend/src/mail/mail.service.spec.ts
+++ b/backend/src/mail/mail.service.spec.ts
@@ -41,6 +41,8 @@ describe('MailService', () => {
       email: 'ana@example.com',
       telefono: '600123123',
       mensaje: 'Quiero ayudar',
+      privacyAccepted: true,
+      acceptedAt: new Date('2026-05-15T12:00:00.000Z'),
     });
 
     expect(sendMail).toHaveBeenCalledWith(
@@ -75,6 +77,8 @@ describe('MailService', () => {
       apellidos: 'López',
       email: 'ana@example.com',
       mensaje: '<script>alert("x")</script>',
+      privacyAccepted: true,
+      acceptedAt: new Date('2026-05-15T12:00:00.000Z'),
     });
 
     expect(sendMail).toHaveBeenCalledWith(
@@ -109,6 +113,8 @@ describe('MailService', () => {
         nombre: 'Ana',
         apellidos: 'Lopez',
         email: 'ana@example.com',
+        privacyAccepted: true,
+        acceptedAt: new Date('2026-05-15T12:00:00.000Z'),
       }),
     ).rejects.toThrow(
       'El servicio de correo no está disponible. Inténtalo de nuevo más tarde.',

--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -116,6 +116,8 @@ Equipo Proclade
     email: string;
     telefono?: string;
     mensaje?: string;
+    privacyAccepted: boolean;
+    acceptedAt: Date;
   }): Promise<void> {
     if (!this.isSmtpConfigured) {
       this.logger.error(
@@ -126,7 +128,7 @@ Equipo Proclade
       );
     }
 
-    const { nombre, apellidos, email, telefono, mensaje } = contactData;
+    const { nombre, apellidos, email, telefono, mensaje, privacyAccepted, acceptedAt } = contactData;
     const safeNombre = this.escapeHtml(nombre);
     const safeApellidos = this.escapeHtml(apellidos);
     const safeEmail = this.escapeHtml(email);
@@ -134,12 +136,19 @@ Equipo Proclade
     const safeMensajeHtml = mensaje
       ? this.escapeHtml(mensaje).replace(/\n/g, '<br />')
       : 'No proporcionado';
+    const acceptedAtIso = acceptedAt.toISOString();
+    const acceptedAtFormatted = acceptedAt.toLocaleString('es-ES', {
+      timeZone: 'Europe/Madrid',
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+    const privacyLabel = privacyAccepted ? 'SÍ' : 'NO';
 
     const mailOptions = {
       from: this.mailFrom,
       to: this.contactFormTo,
       subject: 'Nuevo mensaje de contacto - Colabora',
-      text: `Nuevo mensaje de contacto desde el formulario de colaboración.\n\nNombre: ${nombre}\nApellidos: ${apellidos}\nEmail: ${email}\nTeléfono: ${telefono || 'No proporcionado'}\nMensaje: ${mensaje || 'No proporcionado'}\n\nSistema Proclade`,
+      text: `Nuevo mensaje de contacto desde el formulario de colaboración.\n\nNombre: ${nombre}\nApellidos: ${apellidos}\nEmail: ${email}\nTeléfono: ${telefono || 'No proporcionado'}\nMensaje: ${mensaje || 'No proporcionado'}\n\n--- Metadatos RGPD ---\nAceptación de la Política de privacidad: ${privacyLabel}\nFecha y hora de envío: ${acceptedAtFormatted} (${acceptedAtIso})\nOrigen: Formulario de Colabora\n\nSistema Proclade`,
       html: `
         <div style="font-family: Arial, sans-serif; max-width: 640px; margin: 0 auto; padding: 24px; background: #f8fafc; color: #1f2937;">
           <div style="background: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);">
@@ -174,6 +183,13 @@ Equipo Proclade
                 <div style="background: #f8f9fb; border-radius: 12px; padding: 16px; color: #111827; line-height: 1.7;">
                   ${safeMensajeHtml}
                 </div>
+              </div>
+
+              <div style="margin-top: 24px; padding: 16px; background: #ecfdf5; border-left: 4px solid #16a34a; border-radius: 8px;">
+                <p style="margin: 0 0 6px; font-weight: 700; color: #14532d;">Metadatos RGPD</p>
+                <p style="margin: 0 0 4px; color: #14532d;">✓ Aceptación de la Política de privacidad: <strong>${privacyLabel}</strong></p>
+                <p style="margin: 0 0 4px; color: #14532d;">Fecha y hora del envío: <strong>${acceptedAtFormatted}</strong> (${acceptedAtIso})</p>
+                <p style="margin: 0; color: #14532d;">Origen: Formulario de Colabora</p>
               </div>
 
               <p style="margin: 24px 0 0; font-size: 0.9rem; color: #6b7280;">Este correo se generó desde el formulario de colaboración de Equipo PUCH.</p>

--- a/frontend/src/components/layout/Footer/Footer.tsx
+++ b/frontend/src/components/layout/Footer/Footer.tsx
@@ -3,7 +3,11 @@ import { FooterBrand } from "./shared/FooterBrand/FooterBrand";
 import { FooterColumn } from "./shared/FooterColumn/FooterColumn";
 import { FooterLegal } from "./shared/FooterLegal/FooterLegal";
 
-export const Footer = () => (
+type FooterProps = {
+  onCookiePreferencesClick?: () => void;
+};
+
+export const Footer = ({ onCookiePreferencesClick }: FooterProps) => (
   <footer id="contacto" className="brand-footer section-padding">
     <div className="container">
       <div className="row g-4">
@@ -66,7 +70,7 @@ export const Footer = () => (
 
       <hr className="footer-separator" />
 
-      <FooterLegal />
+      <FooterLegal onCookiePreferencesClick={onCookiePreferencesClick} />
     </div>
   </footer>
 );

--- a/frontend/src/components/layout/Footer/shared/FooterLegal/FooterLegal.css
+++ b/frontend/src/components/layout/Footer/shared/FooterLegal/FooterLegal.css
@@ -9,7 +9,27 @@
 
 .footer-legal__links {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
+  align-items: center;
+}
+
+.footer-legal__link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.footer-legal__link-button:hover,
+.footer-legal__link-button:focus-visible {
+  color: var(--brand-white);
+  text-decoration: underline;
+  outline: none;
 }
 
 @media (max-width: 767.98px) {

--- a/frontend/src/components/layout/Footer/shared/FooterLegal/FooterLegal.tsx
+++ b/frontend/src/components/layout/Footer/shared/FooterLegal/FooterLegal.tsx
@@ -1,6 +1,10 @@
 import './FooterLegal.css';
 
-export const FooterLegal = () => (
+type FooterLegalProps = {
+  onCookiePreferencesClick?: () => void;
+};
+
+export const FooterLegal = ({ onCookiePreferencesClick }: FooterLegalProps) => (
   <div className="footer-legal">
     <p>© 2026 Equipo PUCH. Unidos contra el hambre.</p>
     <div className="footer-legal__links">
@@ -18,6 +22,15 @@ export const FooterLegal = () => (
       >
         Privacidad
       </a>
+      {onCookiePreferencesClick && (
+        <button
+          type="button"
+          className="footer-legal__link-button"
+          onClick={onCookiePreferencesClick}
+        >
+          Configurar cookies
+        </button>
+      )}
     </div>
   </div>
 );

--- a/frontend/src/features/auth/components/LoginForm/LoginForm.css
+++ b/frontend/src/features/auth/components/LoginForm/LoginForm.css
@@ -81,6 +81,54 @@
   background-color: var(--auth-feedback-bg-success);
 }
 
+/* ── Privacy checkbox ── */
+.auth-form__field--checkbox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.auth-form__checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+  color: var(--brand-dark);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.auth-form__checkbox {
+  margin-top: 0.18rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--brand-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.auth-form__checkbox:disabled {
+  cursor: not-allowed;
+}
+
+.auth-form__privacy-link {
+  color: var(--brand-secondary);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.auth-form__privacy-link:hover,
+.auth-form__privacy-link:focus-visible {
+  color: var(--brand-primary);
+}
+
+.auth-form__field-error {
+  margin: 0;
+  color: var(--auth-feedback-error);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
 /* ── Forgot password ── */
 .auth-form__forgot {
   margin: 0.9rem 0 0;

--- a/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm/RegisterForm.tsx
@@ -22,6 +22,8 @@ type RegisterFormState = {
   email: string;
   password: string;
   confirmPassword: string;
+  privacyAccepted: boolean;
+  privacyError: string | null;
   loading: boolean;
   error: string | null;
   successMessage: string | null;
@@ -36,6 +38,8 @@ export const RegisterForm = () => {
     email: '',
     password: '',
     confirmPassword: '',
+    privacyAccepted: false,
+    privacyError: null,
     loading: false,
     error: null,
     successMessage: null,
@@ -48,23 +52,36 @@ export const RegisterForm = () => {
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
+    const { name, value, type, checked } = e.target;
     setFormState((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: type === 'checkbox' ? checked : value,
       error: null,
       successMessage: null,
+      ...(name === 'privacyAccepted' ? { privacyError: null } : {}),
     }));
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (!formState.privacyAccepted) {
+      setFormState((prev) => ({
+        ...prev,
+        privacyError:
+          'Debes aceptar la Política de privacidad para crear una cuenta',
+        error: null,
+        successMessage: null,
+      }));
+      return;
+    }
+
     setFormState((prev) => ({
       ...prev,
       loading: true,
       error: null,
       successMessage: null,
+      privacyError: null,
     }));
 
     const passwordError = validatePasswordPolicy(formState.password);
@@ -95,6 +112,7 @@ export const RegisterForm = () => {
         surname: formState.surname.trim(),
         email: formState.email.trim(),
         password: formState.password,
+        privacyAccepted: true,
       });
 
       if (!response.success || !response.data) {
@@ -240,6 +258,36 @@ export const RegisterForm = () => {
           {formState.error}
         </div>
       )}
+
+      <div className="auth-form__field auth-form__field--checkbox">
+        <label htmlFor="privacyAccepted" className="auth-form__checkbox-label">
+          <input
+            type="checkbox"
+            id="privacyAccepted"
+            name="privacyAccepted"
+            checked={formState.privacyAccepted}
+            onChange={handleChange}
+            disabled={formState.loading}
+            className="auth-form__checkbox"
+          />
+          <span>
+            He leído y acepto la{' '}
+            <a
+              href="https://www.fundacionproclade.org/politica-de-privacidad/"
+              target="_blank"
+              rel="noreferrer"
+              className="auth-form__privacy-link"
+            >
+              Política de privacidad
+            </a>
+          </span>
+        </label>
+        {formState.privacyError && (
+          <p className="auth-form__field-error" role="alert">
+            {formState.privacyError}
+          </p>
+        )}
+      </div>
 
       <button
         type="submit"

--- a/frontend/src/features/auth/types/auth.api.types.ts
+++ b/frontend/src/features/auth/types/auth.api.types.ts
@@ -8,6 +8,7 @@ export type RegisterRequestDto = {
   surname: string;
   email: string;
   password: string;
+  privacyAccepted: boolean;
 };
 
 export type ForgotPasswordRequestDto = {

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.css
@@ -231,6 +231,25 @@
   font-weight: 700;
 }
 
+.chatbot-panel__privacy-notice {
+  margin: 0;
+  padding: 0.55rem 0.85rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  background: rgba(220, 38, 38, 0.06);
+  border-top: 1px solid rgba(13, 59, 115, 0.08);
+  color: var(--brand-dark);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
+.chatbot-panel__privacy-notice i {
+  color: #9f1239;
+  margin-top: 0.1rem;
+  flex-shrink: 0;
+}
+
 .chatbot-panel__composer {
   border-top: 1px solid rgba(13, 59, 115, 0.08);
   padding: 0.72rem;

--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
@@ -147,6 +147,13 @@ export function ChatbotWidget() {
             </p>
           )}
 
+          <p className="chatbot-panel__privacy-notice" role="note">
+            <i className="bi bi-shield-exclamation" aria-hidden="true" />
+            <span>
+              No introduzcas datos sensibles. Las consultas pueden utilizarse para responderte y mejorar la información disponible en la web.
+            </span>
+          </p>
+
           <form className="chatbot-panel__composer" onSubmit={handleSubmit}>
             <label className="visually-hidden" htmlFor="chatbot-input">
               Escribe tu mensaje

--- a/frontend/src/features/colabora/api/colabora.api.ts
+++ b/frontend/src/features/colabora/api/colabora.api.ts
@@ -7,6 +7,7 @@ export type ContactFormData = {
   email: string;
   telefono?: string;
   mensaje?: string;
+  privacyAccepted: boolean;
 };
 
 export async function sendContactForm(

--- a/frontend/src/features/human-libraries/components/DelegationContactPanel/DelegationContactPanel.css
+++ b/frontend/src/features/human-libraries/components/DelegationContactPanel/DelegationContactPanel.css
@@ -30,6 +30,54 @@
   margin-bottom: 0.95rem;
 }
 
+.delegation-contact-panel__map-placeholder {
+  border: 2px dashed rgba(13, 59, 115, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(13, 59, 115, 0.04);
+  padding: 1.4rem 1rem;
+  margin-bottom: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.7rem;
+  min-height: 13rem;
+  justify-content: center;
+}
+
+.delegation-contact-panel__placeholder-icon {
+  font-size: 1.8rem;
+  color: var(--brand-secondary);
+}
+
+.delegation-contact-panel__placeholder-text {
+  margin: 0;
+  color: var(--brand-dark);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.delegation-contact-panel__placeholder-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+  max-width: 22rem;
+}
+
+.delegation-contact-panel__placeholder-actions .btn {
+  width: 100%;
+}
+
+@media (min-width: 576px) {
+  .delegation-contact-panel__placeholder-actions {
+    flex-direction: row;
+  }
+  .delegation-contact-panel__placeholder-actions .btn {
+    flex: 1;
+  }
+}
+
 .delegation-contact-panel__details {
   display: grid;
   gap: 0.55rem;

--- a/frontend/src/features/human-libraries/components/DelegationContactPanel/DelegationContactPanel.tsx
+++ b/frontend/src/features/human-libraries/components/DelegationContactPanel/DelegationContactPanel.tsx
@@ -1,5 +1,14 @@
+import { useEffect, useState } from 'react';
 import type { DelegationContactView } from '../../types/human-libraries.types';
 import { formatRegionPhone } from '../../../../utils/region-phone';
+import {
+  getCookiePreferences,
+  setCookiePreferences,
+} from '../../../privacy/utils/cookie-preferences';
+import {
+  COOKIE_PREFERENCES_EVENT,
+  type CookiePreferences,
+} from '../../../privacy/types/cookie-preferences.types';
 import './DelegationContactPanel.css';
 
 type DelegationContactPanelProps = {
@@ -7,6 +16,23 @@ type DelegationContactPanelProps = {
 };
 
 export const DelegationContactPanel = ({ contact }: DelegationContactPanelProps) => {
+  const [externalServicesAccepted, setExternalServicesAccepted] = useState<boolean>(
+    () => getCookiePreferences().externalServices,
+  );
+
+  useEffect(() => {
+    const handleChange = (event: Event) => {
+      const detail = (event as CustomEvent<CookiePreferences>).detail;
+      if (detail) {
+        setExternalServicesAccepted(detail.externalServices === true);
+      } else {
+        setExternalServicesAccepted(getCookiePreferences().externalServices);
+      }
+    };
+    window.addEventListener(COOKIE_PREFERENCES_EVENT, handleChange);
+    return () => window.removeEventListener(COOKIE_PREFERENCES_EVENT, handleChange);
+  }, []);
+
   const encodedQuery = encodeURIComponent(contact.mapQuery);
   const mapEmbedUrl = `https://www.google.com/maps?q=${encodedQuery}&output=embed`;
   const mapOpenUrl = `https://www.google.com/maps/search/?api=1&query=${encodedQuery}`;
@@ -14,28 +40,68 @@ export const DelegationContactPanel = ({ contact }: DelegationContactPanelProps)
     ? `tel:${contact.phone.replace(/[^+\d]/g, '')}`
     : null;
 
+  const handleAcceptExternalServices = () => {
+    const current = getCookiePreferences();
+    setCookiePreferences({ ...current, externalServices: true });
+  };
+
   return (
     <article className="delegation-contact-panel">
       <h2 className="delegation-contact-panel__title">Mapa y contacto</h2>
 
-      <div className="delegation-contact-panel__map-wrapper">
-        <iframe
-          title={`Mapa de la delegación ${contact.label}`}
-          src={mapEmbedUrl}
-          loading="lazy"
-          referrerPolicy="no-referrer-when-downgrade"
-          className="delegation-contact-panel__map-frame"
-        />
-      </div>
+      {externalServicesAccepted ? (
+        <>
+          <div className="delegation-contact-panel__map-wrapper">
+            <iframe
+              title={`Mapa de la delegación ${contact.label}`}
+              src={mapEmbedUrl}
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+              className="delegation-contact-panel__map-frame"
+            />
+          </div>
 
-      <a
-        href={mapOpenUrl}
-        target="_blank"
-        rel="noreferrer"
-        className="delegation-contact-panel__map-link btn btn-sm btn-brand-outline"
-      >
-        Abrir mapa en Google Maps
-      </a>
+          <a
+            href={mapOpenUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="delegation-contact-panel__map-link btn btn-sm btn-brand-outline"
+          >
+            Abrir mapa en Google Maps
+          </a>
+        </>
+      ) : (
+        <div
+          className="delegation-contact-panel__map-placeholder"
+          role="region"
+          aria-label="Mapa bloqueado por preferencias de privacidad"
+        >
+          <i
+            className="bi bi-geo-alt delegation-contact-panel__placeholder-icon"
+            aria-hidden="true"
+          />
+          <p className="delegation-contact-panel__placeholder-text">
+            Para ver el mapa de Google Maps necesitas aceptar servicios externos.
+          </p>
+          <div className="delegation-contact-panel__placeholder-actions">
+            <button
+              type="button"
+              className="btn btn-sm btn-brand"
+              onClick={handleAcceptExternalServices}
+            >
+              Aceptar servicios externos y ver mapa
+            </button>
+            <a
+              href={mapOpenUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-sm btn-brand-outline"
+            >
+              Abrir ubicación en Google Maps
+            </a>
+          </div>
+        </div>
+      )}
 
       <div className="delegation-contact-panel__details">
         <p>

--- a/frontend/src/features/privacy/components/CookiePreferencesModal/CookiePreferencesModal.css
+++ b/frontend/src/features/privacy/components/CookiePreferencesModal/CookiePreferencesModal.css
@@ -1,0 +1,259 @@
+.cookie-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1080;
+  padding: 1rem;
+  animation: cookieOverlayFade 180ms ease-out;
+}
+
+@keyframes cookieOverlayFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.cookie-modal__container {
+  background: var(--brand-white);
+  border-radius: var(--radius-lg);
+  width: min(36rem, 100%);
+  max-height: min(42rem, 92vh);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.28);
+  animation: cookieContainerSlide 220ms ease-out;
+}
+
+@keyframes cookieContainerSlide {
+  from { opacity: 0; transform: translateY(0.6rem) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.cookie-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.05rem 1.2rem;
+  border-bottom: 1px solid rgba(13, 59, 115, 0.1);
+  background: linear-gradient(135deg, rgba(13, 59, 115, 0.95), rgba(47, 127, 107, 0.95));
+  color: var(--brand-white);
+}
+
+.cookie-modal__title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.cookie-modal__close {
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  color: var(--brand-white);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.cookie-modal__close:hover,
+.cookie-modal__close:focus-visible {
+  background: rgba(255, 255, 255, 0.24);
+  outline: none;
+}
+
+.cookie-modal__body {
+  padding: 1.2rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cookie-modal__intro {
+  margin: 0;
+  color: var(--brand-dark);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.cookie-modal__intro a {
+  color: var(--brand-secondary);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.cookie-modal__actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.55rem;
+  margin-top: 0.4rem;
+}
+
+.cookie-modal__actions--config {
+  grid-template-columns: 1fr 2fr;
+}
+
+.cookie-modal__btn {
+  border-radius: 0.6rem;
+  padding: 0.65rem 0.8rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.cookie-modal__btn--primary {
+  background: var(--brand-primary);
+  color: var(--brand-white);
+}
+
+.cookie-modal__btn--primary:hover,
+.cookie-modal__btn--primary:focus-visible {
+  background: #5a9667;
+  outline: none;
+}
+
+.cookie-modal__btn--secondary {
+  background: var(--brand-white);
+  color: var(--brand-dark);
+  border-color: rgba(13, 59, 115, 0.25);
+}
+
+.cookie-modal__btn--secondary:hover,
+.cookie-modal__btn--secondary:focus-visible {
+  background: rgba(13, 59, 115, 0.06);
+  outline: none;
+}
+
+.cookie-modal__btn--tertiary {
+  background: rgba(13, 59, 115, 0.08);
+  color: var(--brand-secondary);
+  border-color: rgba(13, 59, 115, 0.18);
+}
+
+.cookie-modal__btn--tertiary:hover,
+.cookie-modal__btn--tertiary:focus-visible {
+  background: rgba(13, 59, 115, 0.16);
+  outline: none;
+}
+
+.cookie-modal__categories {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.cookie-modal__category {
+  border: 1px solid rgba(13, 59, 115, 0.12);
+  border-radius: var(--radius-md);
+  padding: 0.85rem;
+  background: rgba(13, 59, 115, 0.03);
+}
+
+.cookie-modal__category--disabled {
+  opacity: 0.65;
+}
+
+.cookie-modal__category-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.4rem;
+}
+
+.cookie-modal__category-title {
+  font-weight: 700;
+  color: var(--brand-secondary);
+  font-size: 0.98rem;
+}
+
+.cookie-modal__category-desc {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  color: var(--brand-muted);
+}
+
+.cookie-modal__badge {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(13, 59, 115, 0.12);
+  color: var(--brand-secondary);
+  font-weight: 700;
+}
+
+.cookie-modal__badge--locked {
+  background: rgba(107, 170, 117, 0.18);
+  color: #1f5f4a;
+}
+
+.cookie-modal__switch {
+  position: relative;
+  display: inline-block;
+  width: 2.4rem;
+  height: 1.32rem;
+  cursor: pointer;
+}
+
+.cookie-modal__switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cookie-modal__switch-slider {
+  position: absolute;
+  inset: 0;
+  background: #cbd5e1;
+  border-radius: 999px;
+  transition: background 160ms ease;
+}
+
+.cookie-modal__switch-slider::before {
+  content: '';
+  position: absolute;
+  height: 1rem;
+  width: 1rem;
+  left: 0.16rem;
+  top: 0.16rem;
+  background: var(--brand-white);
+  border-radius: 50%;
+  transition: transform 160ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.cookie-modal__switch input:checked + .cookie-modal__switch-slider {
+  background: var(--brand-primary);
+}
+
+.cookie-modal__switch input:checked + .cookie-modal__switch-slider::before {
+  transform: translateX(1.06rem);
+}
+
+.cookie-modal__switch input:focus-visible + .cookie-modal__switch-slider {
+  outline: 2px solid rgba(13, 59, 115, 0.5);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .cookie-modal__actions {
+    grid-template-columns: 1fr;
+  }
+  .cookie-modal__actions--config {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/features/privacy/components/CookiePreferencesModal/CookiePreferencesModal.tsx
+++ b/frontend/src/features/privacy/components/CookiePreferencesModal/CookiePreferencesModal.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+import {
+  acceptAllPreferences,
+  getCookiePreferences,
+  rejectAllPreferences,
+  setCookiePreferences,
+} from '../../utils/cookie-preferences';
+import type { CookiePreferences } from '../../types/cookie-preferences.types';
+import './CookiePreferencesModal.css';
+
+type CookiePreferencesModalProps = {
+  onClose: () => void;
+};
+
+type ModalView = 'initial' | 'config';
+
+export const CookiePreferencesModal = ({ onClose }: CookiePreferencesModalProps) => {
+  const [view, setView] = useState<ModalView>('initial');
+  const [draft, setDraft] = useState<CookiePreferences>(() => getCookiePreferences());
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleAcceptAll = () => {
+    acceptAllPreferences();
+    onClose();
+  };
+
+  const handleRejectAll = () => {
+    rejectAllPreferences();
+    onClose();
+  };
+
+  const handleSaveConfig = () => {
+    setCookiePreferences(draft);
+    onClose();
+  };
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="cookie-modal__overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cookie-modal-title"
+      onClick={handleOverlayClick}
+    >
+      <div className="cookie-modal__container">
+        <header className="cookie-modal__header">
+          <h2 id="cookie-modal-title" className="cookie-modal__title">
+            Preferencias de privacidad
+          </h2>
+          <button
+            type="button"
+            className="cookie-modal__close"
+            onClick={onClose}
+            aria-label="Cerrar"
+          >
+            <i className="bi bi-x-lg" aria-hidden="true" />
+          </button>
+        </header>
+
+        {view === 'initial' ? (
+          <div className="cookie-modal__body">
+            <p className="cookie-modal__intro">
+              Equipo PUCH usa almacenamiento técnico necesario para el funcionamiento
+              de la web (sesión, preferencias). Algunos servicios externos como Google
+              Maps no se cargan hasta que tú lo aceptes.
+            </p>
+            <p className="cookie-modal__intro">
+              Consulta la{' '}
+              <a
+                href="https://www.fundacionproclade.org/politica-de-privacidad/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Política de privacidad oficial de PROCLADE
+              </a>{' '}
+              para más detalle.
+            </p>
+            <div className="cookie-modal__actions">
+              <button
+                type="button"
+                className="cookie-modal__btn cookie-modal__btn--secondary"
+                onClick={handleRejectAll}
+              >
+                Rechazar
+              </button>
+              <button
+                type="button"
+                className="cookie-modal__btn cookie-modal__btn--tertiary"
+                onClick={() => setView('config')}
+              >
+                Configurar
+              </button>
+              <button
+                type="button"
+                className="cookie-modal__btn cookie-modal__btn--primary"
+                onClick={handleAcceptAll}
+              >
+                Aceptar
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="cookie-modal__body">
+            <ul className="cookie-modal__categories">
+              <li className="cookie-modal__category">
+                <div className="cookie-modal__category-head">
+                  <span className="cookie-modal__category-title">Necesarias</span>
+                  <span className="cookie-modal__badge cookie-modal__badge--locked">
+                    Siempre activas
+                  </span>
+                </div>
+                <p className="cookie-modal__category-desc">
+                  Imprescindibles para iniciar sesión, recordar tu sesión y mantener
+                  preferencias de la web. Se almacenan en localStorage.
+                </p>
+              </li>
+
+              <li className="cookie-modal__category">
+                <div className="cookie-modal__category-head">
+                  <span className="cookie-modal__category-title">Servicios externos</span>
+                  <label className="cookie-modal__switch">
+                    <input
+                      type="checkbox"
+                      checked={draft.externalServices}
+                      onChange={(event) =>
+                        setDraft((prev) => ({
+                          ...prev,
+                          externalServices: event.target.checked,
+                        }))
+                      }
+                    />
+                    <span className="cookie-modal__switch-slider" />
+                  </label>
+                </div>
+                <p className="cookie-modal__category-desc">
+                  Permite cargar mapas embebidos de Google Maps en las delegaciones.
+                  Al aceptar, Google puede recibir información sobre tu visita según
+                  sus propias políticas.
+                </p>
+              </li>
+
+              <li className="cookie-modal__category cookie-modal__category--disabled">
+                <div className="cookie-modal__category-head">
+                  <span className="cookie-modal__category-title">Analítica</span>
+                  <span className="cookie-modal__badge">No utilizada</span>
+                </div>
+                <p className="cookie-modal__category-desc">
+                  Actualmente no usamos herramientas de analítica ni tracking en esta web.
+                </p>
+              </li>
+            </ul>
+
+            <div className="cookie-modal__actions cookie-modal__actions--config">
+              <button
+                type="button"
+                className="cookie-modal__btn cookie-modal__btn--secondary"
+                onClick={() => setView('initial')}
+              >
+                Volver
+              </button>
+              <button
+                type="button"
+                className="cookie-modal__btn cookie-modal__btn--primary"
+                onClick={handleSaveConfig}
+              >
+                Guardar preferencias
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/privacy/types/cookie-preferences.types.ts
+++ b/frontend/src/features/privacy/types/cookie-preferences.types.ts
@@ -1,0 +1,16 @@
+export type CookieCategory = 'necessary' | 'externalServices' | 'analytics';
+
+export type CookiePreferences = {
+  necessary: true;
+  externalServices: boolean;
+  analytics: boolean;
+};
+
+export const DEFAULT_COOKIE_PREFERENCES: CookiePreferences = {
+  necessary: true,
+  externalServices: false,
+  analytics: false,
+};
+
+export const COOKIE_PREFERENCES_STORAGE_KEY = 'puch_cookie_preferences_v1';
+export const COOKIE_PREFERENCES_EVENT = 'cookiePreferencesChanged';

--- a/frontend/src/features/privacy/utils/cookie-preferences.ts
+++ b/frontend/src/features/privacy/utils/cookie-preferences.ts
@@ -1,0 +1,80 @@
+import {
+  COOKIE_PREFERENCES_EVENT,
+  COOKIE_PREFERENCES_STORAGE_KEY,
+  DEFAULT_COOKIE_PREFERENCES,
+  type CookieCategory,
+  type CookiePreferences,
+} from '../types/cookie-preferences.types';
+
+const isBrowser = (): boolean =>
+  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const sanitize = (raw: unknown): CookiePreferences => {
+  if (raw && typeof raw === 'object') {
+    const candidate = raw as Partial<CookiePreferences>;
+    return {
+      necessary: true,
+      externalServices: candidate.externalServices === true,
+      analytics: candidate.analytics === true,
+    };
+  }
+  return { ...DEFAULT_COOKIE_PREFERENCES };
+};
+
+export const getCookiePreferences = (): CookiePreferences => {
+  if (!isBrowser()) {
+    return { ...DEFAULT_COOKIE_PREFERENCES };
+  }
+
+  try {
+    const stored = window.localStorage.getItem(COOKIE_PREFERENCES_STORAGE_KEY);
+    if (!stored) {
+      return { ...DEFAULT_COOKIE_PREFERENCES };
+    }
+    return sanitize(JSON.parse(stored));
+  } catch {
+    return { ...DEFAULT_COOKIE_PREFERENCES };
+  }
+};
+
+export const setCookiePreferences = (preferences: CookiePreferences): void => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const normalized: CookiePreferences = {
+    necessary: true,
+    externalServices: preferences.externalServices === true,
+    analytics: preferences.analytics === true,
+  };
+
+  try {
+    window.localStorage.setItem(
+      COOKIE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+  } catch {
+    // Ignore localStorage write errors (quota, private mode, etc.)
+  }
+
+  window.dispatchEvent(
+    new CustomEvent(COOKIE_PREFERENCES_EVENT, { detail: normalized }),
+  );
+};
+
+export const acceptAllPreferences = (): void => {
+  setCookiePreferences({
+    necessary: true,
+    externalServices: true,
+    analytics: false,
+  });
+};
+
+export const rejectAllPreferences = (): void => {
+  setCookiePreferences({ ...DEFAULT_COOKIE_PREFERENCES });
+};
+
+export const isCategoryEnabled = (category: CookieCategory): boolean => {
+  const prefs = getCookiePreferences();
+  return prefs[category] === true;
+};

--- a/frontend/src/router/layouts/PublicLayout.tsx
+++ b/frontend/src/router/layouts/PublicLayout.tsx
@@ -1,12 +1,14 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { Header } from "../../components/layout/Header/Header";
 import { Footer } from "../../components/layout/Footer/Footer";
 import { ChatbotWidget } from "../../features/chatbot/components/ChatbotWidget/ChatbotWidget";
+import { CookiePreferencesModal } from "../../features/privacy/components/CookiePreferencesModal/CookiePreferencesModal";
 import "./PublicLayout.css";
 
 export function PublicLayout() {
   const location = useLocation();
+  const [showCookieModal, setShowCookieModal] = useState(false);
 
   useEffect(() => {
     if (!location.hash) {
@@ -39,8 +41,11 @@ export function PublicLayout() {
       <main className="public-layout__content">
         <Outlet />
       </main>
-      <Footer />
+      <Footer onCookiePreferencesClick={() => setShowCookieModal(true)} />
       <ChatbotWidget />
+      {showCookieModal && (
+        <CookiePreferencesModal onClose={() => setShowCookieModal(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/router/pages/ColaboraPage.css
+++ b/frontend/src/router/pages/ColaboraPage.css
@@ -308,6 +308,48 @@
   color: #8f1d1d;
 }
 
+.colabora-page__privacy-notice {
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  background: rgba(13, 59, 115, 0.06);
+  border-left: 3px solid var(--brand-secondary);
+  border-radius: 0.5rem;
+  color: var(--brand-dark);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.colabora-page__privacy-check {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-weight: 500 !important;
+  font-size: 0.9rem;
+  color: var(--brand-dark);
+  cursor: pointer;
+}
+
+.colabora-page__privacy-check input[type='checkbox'] {
+  margin-top: 0.2rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--brand-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.colabora-page__privacy-check a {
+  color: var(--brand-secondary);
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.colabora-page__privacy-check a:hover,
+.colabora-page__privacy-check a:focus-visible {
+  color: var(--brand-primary);
+}
+
 .colabora-page__donation {
   text-align: center;
   padding: clamp(3.8rem, 7vw, 5.5rem) 0;

--- a/frontend/src/router/pages/ColaboraPage.tsx
+++ b/frontend/src/router/pages/ColaboraPage.tsx
@@ -22,6 +22,8 @@ export const ColaboraPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<string>('');
   const [isSuccess, setIsSuccess] = useState<boolean | null>(null);
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [privacyError, setPrivacyError] = useState<string | null>(null);
 
   useEffect(() => {
     void getPublicChallenges()
@@ -52,6 +54,15 @@ export const ColaboraPage = () => {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!privacyAccepted) {
+      setPrivacyError(
+        'Debes aceptar la Política de privacidad para enviar el formulario',
+      );
+      return;
+    }
+
+    setPrivacyError(null);
     setIsLoading(true);
     setMessage('');
     setIsSuccess(null);
@@ -64,6 +75,7 @@ export const ColaboraPage = () => {
       email: formData.get('email') as string,
       telefono: formData.get('telefono') as string || undefined,
       mensaje: formData.get('mensaje') as string || undefined,
+      privacyAccepted: true,
     };
 
     try {
@@ -72,6 +84,7 @@ export const ColaboraPage = () => {
         setMessage('Mensaje enviado correctamente. ¡Gracias por contactar!');
         setIsSuccess(true);
         form.reset();
+        setPrivacyAccepted(false);
       } else {
         setMessage(response.message || 'Error al enviar el mensaje. Inténtalo de nuevo.');
         setIsSuccess(false);
@@ -206,6 +219,40 @@ export const ColaboraPage = () => {
               * Este formulario se envía a info@fundacionproclade.org y te
               responderemos usando los datos que nos facilites.
             </small>
+
+            <p className="colabora-page__privacy-notice">
+              Usaremos tus datos únicamente para responder a tu consulta o gestionar tu solicitud de colaboración.
+            </p>
+
+            <label className="colabora-page__privacy-check">
+              <input
+                type="checkbox"
+                checked={privacyAccepted}
+                onChange={(event) => {
+                  setPrivacyAccepted(event.target.checked);
+                  if (event.target.checked) {
+                    setPrivacyError(null);
+                  }
+                }}
+                disabled={isLoading}
+              />
+              <span>
+                He leído y acepto la{' '}
+                <a
+                  href="https://www.fundacionproclade.org/politica-de-privacidad/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Política de privacidad
+                </a>
+              </span>
+            </label>
+            {privacyError && (
+              <p className="colabora-page__form-feedback colabora-page__form-feedback--error" role="alert">
+                {privacyError}
+              </p>
+            )}
+
             <button type="submit" disabled={isLoading}>
               {isLoading ? 'Enviando...' : 'Enviar'}
             </button>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,4 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;500;600;700;800&family=Sora:wght@600;700;800&display=swap');
+/* Tipografía: se usan fuentes del sistema con fallbacks por privacidad (no se cargan
+   recursos remotos de Google Fonts). Si en el futuro se reactiva una fuente externa,
+   debe cargarse condicionalmente según las preferencias de cookies/servicios externos. */
 
 :root {
   /* Paleta cliente */
@@ -9,8 +11,8 @@
   --puch-green: #6baa75;
 
   /* Tipografia */
-  --font-heading: 'Sora', 'Trebuchet MS', sans-serif;
-  --font-body: 'Nunito Sans', 'Segoe UI', sans-serif;
+  --font-heading: 'Trebuchet MS', 'Segoe UI', system-ui, sans-serif;
+  --font-body: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 
   /* Variables semanticas del proyecto */
   --brand-primary: var(--puch-green);


### PR DESCRIPTION
# HU-28 · Privacidad, RGPD y preferencias de cookies

Como visitante, usuario registrado o persona interesada en colaborar con Equipo PUCH, ahora puedo:

- Saber qué datos personales se recogen y para qué se usan antes de enviarlos.
- Aceptar o rechazar servicios no esenciales (mapas externos, futura analítica) en cualquier momento.
- Consultar fácilmente el aviso legal y la política de privacidad oficiales de PROCLADE.

Con esto la web queda alineada con RGPD, LOPDGDD y LSSI, y se elimina el envío de datos a terceros sin consentimiento previo.

## Cambios principales

### 1. Consentimiento explícito en formularios

- Registro y formulario de Colabora incorporan una casilla obligatoria para aceptar la política de privacidad, con enlace directo a la página oficial de PROCLADE.
- Si no se marca, el formulario no se envía y se muestra un mensaje claro.
- En el alta de usuario se guarda la fecha de aceptación (auditoría RGPD).
- Los emails que recibe Equipo PUCH desde Colabora incluyen un bloque de metadatos RGPD (consentimiento, fecha y origen) para tener trazabilidad documental.

### 2. Modal de preferencias de cookies

- Nuevo botón **“Configurar cookies”** en el footer (junto a “Aviso legal” y “Privacidad”).
- Al pulsarlo se abre un modal con dos vistas:
  - **Inicial**: tres opciones al mismo nivel — Rechazar, Configurar, Aceptar.
  - **Configuración**: tres categorías:
    - **Necesarias** (siempre activas, no se pueden desactivar).
    - **Servicios externos** (Google Maps, etc.) → activable/desactivable.
    - **Analítica** → preparada pero deshabilitada (no hay analítica activa hoy).
- La preferencia se guarda en el navegador y se respeta entre visitas.
- Accesible por teclado: cierre con `Esc`, foco gestionado, etiquetas ARIA.

### 3. Servicios externos solo si el usuario los acepta

- El mapa de Google Maps en las páginas de delegaciones ya no se carga por defecto. En su lugar aparece un cuadro con dos opciones:
  - **“Aceptar servicios externos y ver mapa”** (activa la categoría y muestra el mapa al instante).
  - **“Abrir ubicación en Google Maps”** (abre Google en una pestaña nueva sin embeber nada).
- Eliminada la carga de Google Fonts desde servidores de Google. Ahora se usan tipografías del sistema, así no se hace ninguna petición a terceros al entrar en la web.

### 4. Aviso en el chatbot

- Sobre el campo de mensaje del chatbot aparece un aviso visible recordando que no se deben introducir datos personales sensibles y que las consultas pueden usarse para responder y mejorar la información de la web.

## Cómo probarlo

1. Entra como visitante: el mapa de las delegaciones aparece bloqueado con su placeholder.
2. Pulsa **“Configurar cookies”** en el footer → activa *Servicios externos* → el mapa carga sin recargar la página.
3. Vuelve a abrir el modal y desmárcalo → el mapa vuelve al estado bloqueado.
4. Intenta registrarte o enviar el formulario de Colabora **sin** marcar la casilla de privacidad → debe bloquearse con mensaje de error.
5. Marca la casilla y envía → se completa correctamente; en el correo recibido por Colabora aparecen los metadatos RGPD.
6. Abre el chatbot → comprueba el aviso de privacidad sobre el campo de texto.

## Notas

- No se ha añadido un banner intrusivo en la primera visita: las cookies/servicios externos están **rechazados por defecto** y el usuario los configura cuando quiera desde el footer.
- Los enlaces legales apuntan a las páginas oficiales de **fundacionproclade.org**, no se han creado páginas internas duplicadas.
- Migración de base de datos incluida (campo nuevo `privacyAcceptedAt` en `User`).