### PR TITLE
fix(chatbot): ocultar aviso de privacidad tras la primera interaccion

### DIFF
--- a/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
+++ b/frontend/src/features/chatbot/components/ChatbotWidget/ChatbotWidget.tsx
@@ -12,6 +12,7 @@ export function ChatbotWidget() {
   const location = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   const [draftMessage, setDraftMessage] = useState('');
+  const [hasInteracted, setHasInteracted] = useState(false);
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const {
     messages,
@@ -59,6 +60,7 @@ export function ChatbotWidget() {
     }
 
     setDraftMessage('');
+    setHasInteracted(true);
     void sendMessage(nextMessage, pageContext);
   };
 
@@ -68,6 +70,7 @@ export function ChatbotWidget() {
     }
 
     setDraftMessage('');
+    setHasInteracted(true);
     void sendMessage(suggestion, pageContext);
   };
 
@@ -147,12 +150,14 @@ export function ChatbotWidget() {
             </p>
           )}
 
-          <p className="chatbot-panel__privacy-notice" role="note">
-            <i className="bi bi-shield-exclamation" aria-hidden="true" />
-            <span>
-              No introduzcas datos sensibles. Las consultas pueden utilizarse para responderte y mejorar la información disponible en la web.
-            </span>
-          </p>
+          {!hasInteracted && (
+            <p className="chatbot-panel__privacy-notice" role="note">
+              <i className="bi bi-shield-exclamation" aria-hidden="true" />
+              <span>
+                No introduzcas datos sensibles. Las consultas pueden utilizarse para responderte y mejorar la información disponible en la web.
+              </span>
+            </p>
+          )}
 
           <form className="chatbot-panel__composer" onSubmit={handleSubmit}>
             <label className="visually-hidden" htmlFor="chatbot-input">


### PR DESCRIPTION
- El aviso 'No introduzcas datos sensibles' deja de mostrarse en cuanto el usuario envia un mensaje o pulsa una sugerencia, para no estorbar durante la conversacion.

- Al recargar la pagina o iniciar nueva sesion vuelve a aparecer.